### PR TITLE
Implement HMAC-SHA256 Webhook Signature Security

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -11,3 +11,7 @@ STELLAR_HORIZON_URL=
 
 # Optional asset issuers
 USDC_ISSUER=your_usdc_issuer
+
+# Webhook signing – shared secret used to produce Stellar-Signature: sha256=<hmac>
+# Generate a strong random value, e.g.: openssl rand -hex 32
+WEBHOOK_SECRET=your_webhook_secret

--- a/backend/src/lib/webhooks.js
+++ b/backend/src/lib/webhooks.js
@@ -1,23 +1,64 @@
-export async function sendWebhook(url, payload) {
+import { createHmac } from "crypto";
+
+/**
+ * Signs a serialised payload string with HMAC-SHA256 using the shared secret.
+ *
+ * @param {string} rawBody   - The exact JSON string that will be sent as the
+ *                             request body (produced by JSON.stringify(payload)).
+ * @param {string} secret    - The merchant's shared webhook secret.
+ * @returns {string}           Hex-encoded HMAC-SHA256 digest.
+ */
+export function signPayload(rawBody, secret) {
+  return createHmac("sha256", secret).update(rawBody).digest("hex");
+}
+
+/**
+ * Sends a signed webhook POST request to `url`.
+ *
+ * When WEBHOOK_SECRET is set (or a per-call `secret` is provided) the
+ * serialised body is signed and the signature is attached as:
+ *
+ *   Stellar-Signature: sha256=<hex-digest>
+ *
+ * Merchants verify authenticity by computing the same HMAC over the raw
+ * request body and comparing it to this header value.
+ *
+ * @param {string} url        - Merchant webhook endpoint.
+ * @param {object} payload    - Data to send (will be JSON-serialised).
+ * @param {string} [secret]   - Overrides the WEBHOOK_SECRET env var when
+ *                              supplied (useful for per-merchant secrets).
+ * @returns {Promise<{ok:boolean, skipped?:boolean, status?:number, body?:string, error?:string, signed?:boolean}>}
+ */
+export async function sendWebhook(url, payload, secret) {
   if (!url) return { ok: false, skipped: true };
+
+  const signingSecret = secret || process.env.WEBHOOK_SECRET || "";
+  const rawBody = JSON.stringify(payload);
+
+  const headers = {
+    "Content-Type": "application/json",
+    "User-Agent": "stellar-payment-api/0.1"
+  };
+
+  if (signingSecret) {
+    const signature = signPayload(rawBody, signingSecret);
+    headers["Stellar-Signature"] = `sha256=${signature}`;
+  }
 
   try {
     const response = await fetch(url, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "User-Agent": "stellar-payment-api/0.1"
-      },
-      body: JSON.stringify(payload)
+      headers,
+      body: rawBody
     });
 
     if (!response.ok) {
       const text = await response.text().catch(() => "");
-      return { ok: false, status: response.status, body: text };
+      return { ok: false, status: response.status, body: text, signed: !!signingSecret };
     }
 
-    return { ok: true, status: response.status };
+    return { ok: true, status: response.status, signed: !!signingSecret };
   } catch (err) {
-    return { ok: false, error: err.message };
+    return { ok: false, error: err.message, signed: !!signingSecret };
   }
 }


### PR DESCRIPTION
### Description
This PR enhances the security of the webhook delivery system by implementing payload signing. It allows merchants to verify the authenticity and integrity of incoming notifications from the Stellar Payment API using a shared secret, preventing spoofing and "Man-in-the-Middle" attacks.

---

### Key Changes
* **New Signing Utility:** Added `signPayload(rawBody, secret)` in `backend/src/lib/webhooks.js` using `crypto.createHmac(sha256)`.
* **Standardized Headers:** Updated `sendWebhook` to attach a `Stellar-Signature: sha256=<hex>` header when a secret is present.
* **Canonical Serialization:** Ensured the payload is serialized once to a string (`rawBody`) before signing to ensure the signature matches the exact bytes sent over the wire.
* **Backward Compatibility:** Maintained unsigned delivery as a fallback when no secret is configured, ensuring existing integrations remain functional.
* **Environment Configuration:** Updated `backend/.env.example` to include `WEBHOOK_SECRET` with instructions for generating a secure 32-byte hex key.

---

### How to Test
1. **Set** a `WEBHOOK_SECRET` in your `.env` file (e.g., `openssl rand -hex 32`).
2. **Trigger** a webhook event (e.g., via a test payment).
3. **Verify** the presence of the `Stellar-Signature` header in the outgoing request.
4. **Validation:** Re-calculate the HMAC-SHA256 of the raw body using the secret and ensure it matches the header value.

closes #2 
