### PR TITLE
feat: add multi-stage production Dockerfile and .dockerignore

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,29 @@
+# Dependencies (re-installed inside Docker)
+node_modules
+
+# Environment files – never bake secrets into images
+.env
+.env.*
+!.env.example
+
+# Version control
+.git
+.gitignore
+
+# Editors / OS noise
+.vscode
+.idea
+*.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+npm-debug.log*
+
+# Test & coverage output
+coverage
+*.test.js
+*.spec.js
+
+# CI / tooling configs not needed at runtime
+.github

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,46 @@
+# ─────────────────────────────────────────────
+#  Stage 1 – install production dependencies
+# ─────────────────────────────────────────────
+FROM node:20-alpine AS deps
+
+# Install OS-level build tools required by some native add-ons
+RUN apk add --no-cache libc6-compat
+
+WORKDIR /app
+
+# Copy only the manifests so Docker can cache this layer
+COPY package.json package-lock.json ./
+
+# Install ONLY production dependencies (skip devDependencies)
+RUN npm ci --omit=dev
+
+# ─────────────────────────────────────────────
+#  Stage 2 – production image
+# ─────────────────────────────────────────────
+FROM node:20-alpine AS runner
+
+# Security best-practice: run as non-root user
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=4000
+
+# Copy installed production node_modules from deps stage
+COPY --from=deps /app/node_modules ./node_modules
+
+# Copy application source
+COPY src ./src
+COPY package.json ./
+
+# Use non-root user from this point forward
+USER appuser
+
+EXPOSE 4000
+
+# Health-check using the existing /health endpoint
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://localhost:4000/health || exit 1
+
+CMD ["node", "src/index.js"]


### PR DESCRIPTION
Closes #50 

- Two-stage build using node:20-alpine (deps + runner)
- Stage 1 installs only production dependencies via npm ci --omit=dev
- Stage 2 copies source and runs as non-root user (appuser)
- Sets NODE_ENV=production and exposes port 4000
- HEALTHCHECK wired to existing /health endpoint
- .dockerignore excludes node_modules, .env files, .git, logs and tests
