### PR TITLE
fix: implement backend issues #5, #6, #12, #16

### DIFF
--- a/backend/sql/schema.sql
+++ b/backend/sql/schema.sql
@@ -16,6 +16,8 @@ create table if not exists payments (
   asset_issuer text,
   recipient text not null,
   description text,
+  memo text,
+  memo_type text,
   webhook_url text,
   status text not null default 'pending',
   tx_id text,

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -17,7 +17,7 @@ app.get("/health", (req, res) => {
 });
 
 app.use("/api", paymentsRouter);
-app.use("/api/merchants", merchantsRouter);
+app.use("/api", merchantsRouter);
 
 app.use((err, req, res, next) => {
   const status = err.status || 500;

--- a/backend/src/lib/stellar.js
+++ b/backend/src/lib/stellar.js
@@ -47,20 +47,84 @@ function paymentMatchesAsset(payment, asset) {
   );
 }
 
+/**
+ * Wraps Horizon SDK errors into descriptive, consumer-friendly Error objects.
+ */
+function handleHorizonError(err, context = "") {
+  const status = err?.response?.status;
+
+  if (status === 429) {
+    const error = new Error(
+      "Horizon rate limit exceeded. Please retry after a short wait."
+    );
+    error.status = 429;
+    return error;
+  }
+
+  if (status === 404) {
+    const error = new Error(
+      `Stellar account not found${context ? `: ${context}` : ""}`
+    );
+    error.status = 404;
+    return error;
+  }
+
+  if (status && status >= 400 && status < 500) {
+    const detail = err?.response?.data?.detail || err.message;
+    const error = new Error(`Horizon request error (${status}): ${detail}`);
+    error.status = status;
+    return error;
+  }
+
+  if (status && status >= 500) {
+    const error = new Error(
+      `Horizon server error (${status}). The Stellar network may be experiencing issues.`
+    );
+    error.status = 502;
+    return error;
+  }
+
+  // Network / connection errors (ECONNREFUSED, timeout, etc.)
+  const error = new Error(
+    `Unable to connect to Horizon (${HORIZON_URL}): ${err.message}`
+  );
+  error.status = 502;
+  return error;
+}
+
+/**
+ * Returns true when the on-chain transaction memo matches the expected values.
+ * If no memo is expected the check is skipped (backward-compatible).
+ */
+function memoMatches(tx, expectedMemo, expectedMemoType) {
+  const txMemoType = (tx.memo_type || "none").toLowerCase();
+  const wantType = (expectedMemoType || "text").toLowerCase();
+
+  if (txMemoType !== wantType) return false;
+  return String(tx.memo) === String(expectedMemo);
+}
+
 export async function findMatchingPayment({
   recipient,
   amount,
   assetCode,
-  assetIssuer
+  assetIssuer,
+  memo,
+  memoType
 }) {
   const asset = resolveAsset(assetCode, assetIssuer);
 
-  const page = await server
-    .payments()
-    .forAccount(recipient)
-    .order("desc")
-    .limit(200)
-    .call();
+  let page;
+  try {
+    page = await server
+      .payments()
+      .forAccount(recipient)
+      .order("desc")
+      .limit(200)
+      .call();
+  } catch (err) {
+    throw handleHorizonError(err, recipient);
+  }
 
   for (const payment of page.records) {
     if (payment.type !== "payment") {
@@ -73,6 +137,23 @@ export async function findMatchingPayment({
 
     if (!amountsMatch(amount, payment.amount)) {
       continue;
+    }
+
+    // If a memo is expected, fetch the parent transaction and compare
+    if (memo != null && memo !== "") {
+      try {
+        const tx = await server
+          .transactions()
+          .transaction(payment.transaction_hash)
+          .call();
+
+        if (!memoMatches(tx, memo, memoType)) {
+          continue;
+        }
+      } catch (_txErr) {
+        // Cannot verify memo — skip this candidate
+        continue;
+      }
     }
 
     return {

--- a/backend/src/lib/stellar.test.js
+++ b/backend/src/lib/stellar.test.js
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 // vi.hoisted makes mockCall available inside the vi.mock factory (which is hoisted above imports)
-const { mockCall } = vi.hoisted(() => ({ mockCall: vi.fn() }))
+const { mockCall, mockTxCall } = vi.hoisted(() => ({
+  mockCall: vi.fn(),
+  mockTxCall: vi.fn()
+}))
 
 vi.mock('stellar-sdk', () => {
   const MockAsset = vi.fn((code, issuer) => ({ isNative: () => false, code, issuer }))
@@ -13,6 +16,11 @@ vi.mock('stellar-sdk', () => {
         order: () => ({
           limit: () => ({ call: mockCall })
         })
+      })
+    }),
+    transactions: () => ({
+      transaction: () => ({
+        call: mockTxCall
       })
     })
   }))
@@ -35,7 +43,10 @@ const makePayment = (overrides = {}) => ({
 const USDC_ISSUER = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5'
 
 describe('findMatchingPayment', () => {
-  beforeEach(() => mockCall.mockReset())
+  beforeEach(() => {
+    mockCall.mockReset()
+    mockTxCall.mockReset()
+  })
 
   it('returns matching XLM payment', async () => {
     mockCall.mockResolvedValue({ records: [makePayment()] })
@@ -160,5 +171,167 @@ describe('findMatchingPayment', () => {
     })
 
     expect(result).toEqual({ id: 'op-first', transaction_hash: 'tx-first' })
+  })
+
+  // ── Memo matching (Issue #16) ──────────────────────────────────────
+
+  it('matches payment with correct text memo', async () => {
+    mockCall.mockResolvedValue({ records: [makePayment()] })
+    mockTxCall.mockResolvedValue({ memo_type: 'text', memo: 'order-123' })
+
+    const result = await findMatchingPayment({
+      recipient: 'GABC',
+      amount: '100',
+      assetCode: 'XLM',
+      memo: 'order-123',
+      memoType: 'text'
+    })
+
+    expect(result).toEqual({ id: 'op-1', transaction_hash: 'tx-abc123' })
+  })
+
+  it('rejects payment with wrong memo value', async () => {
+    mockCall.mockResolvedValue({ records: [makePayment()] })
+    mockTxCall.mockResolvedValue({ memo_type: 'text', memo: 'wrong-memo' })
+
+    const result = await findMatchingPayment({
+      recipient: 'GABC',
+      amount: '100',
+      assetCode: 'XLM',
+      memo: 'order-123',
+      memoType: 'text'
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('rejects payment with wrong memo type', async () => {
+    mockCall.mockResolvedValue({ records: [makePayment()] })
+    mockTxCall.mockResolvedValue({ memo_type: 'id', memo: '12345' })
+
+    const result = await findMatchingPayment({
+      recipient: 'GABC',
+      amount: '100',
+      assetCode: 'XLM',
+      memo: '12345',
+      memoType: 'text'
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('matches id memo type', async () => {
+    mockCall.mockResolvedValue({ records: [makePayment()] })
+    mockTxCall.mockResolvedValue({ memo_type: 'id', memo: '9876' })
+
+    const result = await findMatchingPayment({
+      recipient: 'GABC',
+      amount: '100',
+      assetCode: 'XLM',
+      memo: '9876',
+      memoType: 'id'
+    })
+
+    expect(result).toEqual({ id: 'op-1', transaction_hash: 'tx-abc123' })
+  })
+
+  it('matches hash memo type', async () => {
+    const hash = 'abc123def456'
+    mockCall.mockResolvedValue({ records: [makePayment()] })
+    mockTxCall.mockResolvedValue({ memo_type: 'hash', memo: hash })
+
+    const result = await findMatchingPayment({
+      recipient: 'GABC',
+      amount: '100',
+      assetCode: 'XLM',
+      memo: hash,
+      memoType: 'hash'
+    })
+
+    expect(result).toEqual({ id: 'op-1', transaction_hash: 'tx-abc123' })
+  })
+
+  it('skips memo check when no memo is provided', async () => {
+    mockCall.mockResolvedValue({ records: [makePayment()] })
+
+    const result = await findMatchingPayment({
+      recipient: 'GABC',
+      amount: '100',
+      assetCode: 'XLM'
+    })
+
+    expect(result).toEqual({ id: 'op-1', transaction_hash: 'tx-abc123' })
+    expect(mockTxCall).not.toHaveBeenCalled()
+  })
+
+  it('skips payment when transaction fetch fails during memo check', async () => {
+    mockCall.mockResolvedValue({ records: [makePayment()] })
+    mockTxCall.mockRejectedValue(new Error('tx fetch failed'))
+
+    const result = await findMatchingPayment({
+      recipient: 'GABC',
+      amount: '100',
+      assetCode: 'XLM',
+      memo: 'order-123',
+      memoType: 'text'
+    })
+
+    expect(result).toBeNull()
+  })
+
+  // ── Horizon error handling (Issue #5) ──────────────────────────────
+
+  it('throws descriptive error on rate limit (429)', async () => {
+    mockCall.mockRejectedValue({ response: { status: 429 } })
+
+    await expect(
+      findMatchingPayment({ recipient: 'GABC', amount: '100', assetCode: 'XLM' })
+    ).rejects.toThrow(/rate limit/i)
+  })
+
+  it('throws descriptive error on account not found (404)', async () => {
+    mockCall.mockRejectedValue({ response: { status: 404 } })
+
+    await expect(
+      findMatchingPayment({ recipient: 'GABC', amount: '100', assetCode: 'XLM' })
+    ).rejects.toThrow(/not found/i)
+  })
+
+  it('throws descriptive error on Horizon server error (500)', async () => {
+    mockCall.mockRejectedValue({ response: { status: 500 } })
+
+    await expect(
+      findMatchingPayment({ recipient: 'GABC', amount: '100', assetCode: 'XLM' })
+    ).rejects.toThrow(/server error/i)
+  })
+
+  it('throws descriptive error on network failure', async () => {
+    mockCall.mockRejectedValue(new Error('ECONNREFUSED'))
+
+    await expect(
+      findMatchingPayment({ recipient: 'GABC', amount: '100', assetCode: 'XLM' })
+    ).rejects.toThrow(/unable to connect/i)
+  })
+
+  it('sets status 429 for rate-limit errors', async () => {
+    mockCall.mockRejectedValue({ response: { status: 429 } })
+
+    try {
+      await findMatchingPayment({ recipient: 'GABC', amount: '100', assetCode: 'XLM' })
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err.status).toBe(429)
+    }
+  })
+
+  it('sets status 502 for network errors', async () => {
+    mockCall.mockRejectedValue(new Error('ECONNREFUSED'))
+
+    try {
+      await findMatchingPayment({ recipient: 'GABC', amount: '100', assetCode: 'XLM' })
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err.status).toBe(502)
+    }
   })
 })

--- a/backend/src/routes/merchants.js
+++ b/backend/src/routes/merchants.js
@@ -4,7 +4,7 @@ import { supabase } from "../lib/supabase.js";
 
 const router = express.Router();
 
-const REQUIRED_FIELDS = ["email", "business_name", "notification_email"];
+const REQUIRED_FIELDS = ["email"];
 
 function validateRegisterMerchant(body) {
   for (const field of REQUIRED_FIELDS) {
@@ -18,7 +18,7 @@ function validateRegisterMerchant(body) {
   if (!emailRegex.test(body.email)) {
     return "Invalid email format";
   }
-  if (!emailRegex.test(body.notification_email)) {
+  if (body.notification_email && !emailRegex.test(body.notification_email)) {
     return "Invalid notification_email format";
   }
 
@@ -29,14 +29,16 @@ function validateRegisterMerchant(body) {
  * POST /register
  * Creates a new merchant profile and returns an API key.
  */
-router.post("/register", async (req, res, next) => {
+router.post("/register-merchant", async (req, res, next) => {
   try {
     const error = validateRegisterMerchant(req.body || {});
     if (error) {
       return res.status(400).json({ error });
     }
 
-    const { email, business_name, notification_email } = req.body;
+    const { email } = req.body;
+    const business_name = req.body.business_name || email.split("@")[0];
+    const notification_email = req.body.notification_email || email;
 
     // Check if merchant already exists
     const { data: existing } = await supabase

--- a/backend/src/routes/payments.js
+++ b/backend/src/routes/payments.js
@@ -8,6 +8,8 @@ const router = express.Router();
 
 const REQUIRED_FIELDS = ["amount", "asset", "recipient"];
 
+const VALID_MEMO_TYPES = ["text", "id", "hash", "return"];
+
 function validateCreatePayment(body) {
   for (const field of REQUIRED_FIELDS) {
     if (!body[field]) {
@@ -20,10 +22,21 @@ function validateCreatePayment(body) {
   }
 
   const asset = String(body.asset || "").toUpperCase();
-  const hasIssuer =
-    body.asset_issuer || (asset === "USDC" && process.env.USDC_ISSUER);
-  if (asset !== "XLM" && !hasIssuer) {
+  if (asset !== "XLM" && !body.asset_issuer) {
     return "asset_issuer is required for non-native assets";
+  }
+
+  if (body.memo && !body.memo_type) {
+    return "memo_type is required when memo is provided";
+  }
+  if (body.memo_type && !body.memo) {
+    return "memo is required when memo_type is provided";
+  }
+  if (
+    body.memo_type &&
+    !VALID_MEMO_TYPES.includes(body.memo_type.toLowerCase())
+  ) {
+    return `Invalid memo_type. Must be one of: ${VALID_MEMO_TYPES.join(", ")}`;
   }
 
   return null;
@@ -42,9 +55,7 @@ router.post("/create-payment", async (req, res, next) => {
     const paymentLink = `${paymentLinkBase}/pay/${paymentId}`;
 
     const asset = String(req.body.asset || "").toUpperCase();
-    const assetIssuer =
-      req.body.asset_issuer ||
-      (asset === "USDC" ? process.env.USDC_ISSUER : null);
+    const assetIssuer = req.body.asset_issuer || null;
 
     const payload = {
       id: paymentId,
@@ -54,6 +65,8 @@ router.post("/create-payment", async (req, res, next) => {
       asset_issuer: assetIssuer,
       recipient: req.body.recipient,
       description: req.body.description || null,
+      memo: req.body.memo || null,
+      memo_type: req.body.memo_type ? req.body.memo_type.toLowerCase() : null,
       webhook_url: req.body.webhook_url || null,
       status: "pending",
       tx_id: null,
@@ -84,7 +97,7 @@ router.get("/payment-status/:id", async (req, res, next) => {
     const { data, error } = await supabase
       .from("payments")
       .select(
-        "id, amount, asset, asset_issuer, recipient, description, status, tx_id, created_at"
+        "id, amount, asset, asset_issuer, recipient, description, memo, memo_type, status, tx_id, created_at"
       )
       .eq("id", req.params.id)
       .maybeSingle();
@@ -109,7 +122,7 @@ router.post("/verify-payment/:id", async (req, res, next) => {
     const { data, error } = await supabase
       .from("payments")
       .select(
-        "id, amount, asset, asset_issuer, recipient, status, tx_id, webhook_url, merchants(webhook_secret)"
+        "id, amount, asset, asset_issuer, recipient, status, tx_id, memo, memo_type, webhook_url, merchants(webhook_secret)"
       )
       .eq("id", req.params.id)
       .maybeSingle();
@@ -131,7 +144,9 @@ router.post("/verify-payment/:id", async (req, res, next) => {
       recipient: data.recipient,
       amount: data.amount,
       assetCode: data.asset,
-      assetIssuer: data.asset_issuer
+      assetIssuer: data.asset_issuer,
+      memo: data.memo,
+      memoType: data.memo_type
     });
 
     if (!match) {


### PR DESCRIPTION
- Closes #6   Asset Validation: Remove USDC special-case; require explicit asset_issuer for every non-native asset in validateCreatePayment.

- Closes #12  Merchant Onboarding: Expose POST /api/register-merchant that only requires an email, defaults business_name & notification_email, and returns a generated API key + webhook secret.

- Closes #16  Memo Support: Accept memo & memo_type on payment creation, persist them, and compare on-chain transaction memos in findMatchingPayment (text, id, hash, return types).

- Closes #5    Horizon Error Handling: Wrap all Horizon server calls in try-catch with descriptive, status-coded errors for 429 rate-limit, 404 account-not-found, 5xx server errors, and network failures.

Tests: 21 passing (8 existing + 7 memo + 6 error-handling).