### PR TITLE
feat: implement API key authentication

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -4,6 +4,7 @@ import morgan from "morgan";
 import cors from "cors";
 import paymentsRouter from "./routes/payments.js";
 import merchantsRouter from "./routes/merchants.js";
+import { requireApiKeyAuth } from "./lib/auth.js";
 
 const app = express();
 const port = process.env.PORT || 4000;
@@ -19,6 +20,7 @@ app.get("/health", (req, res) => {
   res.json({ ok: true, service: "stellar-payment-api" });
 });
 
+app.use("/api/create-payment", requireApiKeyAuth());
 app.use("/api", paymentsRouter);
 app.use("/api", merchantsRouter);
 

--- a/backend/src/lib/auth.js
+++ b/backend/src/lib/auth.js
@@ -1,0 +1,37 @@
+export function createApiKeyAuth({ supabaseClient = null } = {}) {
+  return async function requireApiKeyAuth(req, res, next) {
+    try {
+      const client = supabaseClient || (await import("./supabase.js")).supabase;
+      const headerValue = req.get("x-api-key");
+      const apiKey = typeof headerValue === "string" ? headerValue.trim() : "";
+
+      if (!apiKey) {
+        return res.status(401).json({ error: "Missing x-api-key header" });
+      }
+
+      const { data: merchant, error } = await client
+        .from("merchants")
+        .select("id, email, business_name, notification_email")
+        .eq("api_key", apiKey)
+        .maybeSingle();
+
+      if (error) {
+        error.status = 500;
+        throw error;
+      }
+
+      if (!merchant) {
+        return res.status(401).json({ error: "Invalid API key" });
+      }
+
+      req.merchant = merchant;
+      next();
+    } catch (err) {
+      next(err);
+    }
+  };
+}
+
+export function requireApiKeyAuth(options) {
+  return createApiKeyAuth(options);
+}

--- a/backend/src/lib/auth.test.js
+++ b/backend/src/lib/auth.test.js
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createApiKeyAuth } from "./auth.js";
+
+function createResponse() {
+  return {
+    status: vi.fn(),
+    json: vi.fn()
+  };
+}
+
+function createRequest(headers = {}) {
+  return {
+    get(name) {
+      return headers[name.toLowerCase()];
+    }
+  };
+}
+
+describe("createApiKeyAuth", () => {
+  let maybeSingle;
+  let eq;
+  let select;
+  let from;
+  let supabaseClient;
+  let middleware;
+  let res;
+  let next;
+
+  beforeEach(() => {
+    maybeSingle = vi.fn();
+    eq = vi.fn(() => ({ maybeSingle }));
+    select = vi.fn(() => ({ eq }));
+    from = vi.fn(() => ({ select }));
+    supabaseClient = { from };
+    middleware = createApiKeyAuth({ supabaseClient });
+    res = createResponse();
+    res.status.mockReturnValue(res);
+    next = vi.fn();
+  });
+
+  it("rejects requests without an x-api-key header", async () => {
+    const req = createRequest();
+
+    await middleware(req, res, next);
+
+    expect(from).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: "Missing x-api-key header" });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("rejects requests with an invalid API key", async () => {
+    maybeSingle.mockResolvedValue({ data: null, error: null });
+    const req = createRequest({ "x-api-key": "invalid-key" });
+
+    await middleware(req, res, next);
+
+    expect(from).toHaveBeenCalledWith("merchants");
+    expect(select).toHaveBeenCalledWith("id, email, business_name, notification_email");
+    expect(eq).toHaveBeenCalledWith("api_key", "invalid-key");
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: "Invalid API key" });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("attaches the authenticated merchant to the request", async () => {
+    const merchant = {
+      id: "merchant-123",
+      email: "merchant@example.com",
+      business_name: "Merchant Co",
+      notification_email: "ops@example.com"
+    };
+    maybeSingle.mockResolvedValue({ data: merchant, error: null });
+    const req = createRequest({ "x-api-key": "  valid-key  " });
+
+    await middleware(req, res, next);
+
+    expect(eq).toHaveBeenCalledWith("api_key", "valid-key");
+    expect(req.merchant).toEqual(merchant);
+    expect(next).toHaveBeenCalledWith();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("forwards Supabase lookup failures to the error handler", async () => {
+    const error = new Error("Supabase unavailable");
+    maybeSingle.mockResolvedValue({ data: null, error });
+    const req = createRequest({ "x-api-key": "valid-key" });
+
+    await middleware(req, res, next);
+
+    expect(error.status).toBe(500);
+    expect(next).toHaveBeenCalledWith(error);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/routes/payments.js
+++ b/backend/src/routes/payments.js
@@ -60,7 +60,7 @@ router.post("/create-payment", async (req, res, next) => {
 
     const payload = {
       id: paymentId,
-      merchant_id: req.body.merchant_id || null,
+      merchant_id: req.merchant.id,
       amount: Number(req.body.amount),
       asset,
       asset_issuer: assetIssuer,


### PR DESCRIPTION


## Summary
- add API key authentication middleware for `/api/create-payment`
- extract `x-api-key` from request headers and validate it against the `api_key` column in the `merchants` table
- attach the authenticated merchant record to `req.merchant`
- stop trusting `merchant_id` from the request body and persist the authenticated merchant ID instead
- add backend tests covering missing API keys, invalid API keys, successful merchant attachment, and Supabase lookup failures

## Security Notes
- payment creation is now gated by a merchant-owned API key
- callers can no longer create payments on behalf of another merchant by supplying a different `merchant_id` in the request body
- invalid or missing API keys return `401 Unauthorized`
- Supabase lookup failures are forwarded to the existing Express error handler as server errors

## Testing
- `cd backend && npm test`

## Files
- `backend/src/index.js`
- `backend/src/routes/payments.js`
- `backend/src/lib/auth.js`
- `backend/src/lib/auth.test.js`

Closes #1
Closes #4 
Closes #8 
Closes #9 