### PR TITLE
feat: add webhook delivery logs table

### DIFF
--- a/backend/sql/schema.sql
+++ b/backend/sql/schema.sql
@@ -26,3 +26,14 @@ create table if not exists payments (
 
 create index if not exists payments_status_idx on payments(status);
 create index if not exists payments_merchant_idx on payments(merchant_id);
+
+create table if not exists webhook_delivery_logs (
+  id uuid primary key default gen_random_uuid(),
+  payment_id uuid references payments(id) on delete cascade,
+  status_code integer not null,
+  response_body text,
+  timestamp timestamptz not null default now()
+);
+
+create index if not exists webhook_delivery_logs_payment_idx on webhook_delivery_logs(payment_id);
+create index if not exists webhook_delivery_logs_timestamp_idx on webhook_delivery_logs(timestamp);


### PR DESCRIPTION
## Summary

This PR adds a new `webhook_delivery_logs` table to track webhook delivery attempts for better monitoring and debugging.

## Changes

- Added `webhook_delivery_logs` table with the following fields:
  - `id`: UUID primary key
  - `payment_id`: Reference to payments table
  - `status_code`: HTTP response status code from webhook delivery
  - `response_body`: Response body from the webhook endpoint
  - `timestamp`: When the webhook was delivered
- Added indexes on `payment_id` and `timestamp` for efficient querying
- Used `on delete cascade` to automatically clean up logs when payments are deleted

## Testing

Schema changes can be applied by running the updated `backend/sql/schema.sql` file against your database.

Closes #3