### PR TITLE
fix(health): verify supabase connectivity

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -7,6 +7,7 @@ import swaggerUi from "swagger-ui-express";
 import paymentsRouter from "./routes/payments.js";
 import merchantsRouter from "./routes/merchants.js";
 import { requireApiKeyAuth } from "./lib/auth.js";
+import { supabase } from "./lib/supabase.js";
 
 const app = express();
 const port = process.env.PORT || 4000;
@@ -33,8 +34,26 @@ app.use(cors({
 app.use(express.json({ limit: "1mb" }));
 app.use(morgan("dev"));
 
-app.get("/health", (req, res) => {
-  res.json({ ok: true, service: "stellar-payment-api" });
+app.get("/health", async (req, res) => {
+  try {
+    const { error } = await supabase.from("merchants").select("id").limit(1);
+
+    if (error) {
+      return res.status(503).json({
+        ok: false,
+        service: "stellar-payment-api",
+        error: "Database unavailable"
+      });
+    }
+
+    res.json({ ok: true, service: "stellar-payment-api" });
+  } catch {
+    res.status(503).json({
+      ok: false,
+      service: "stellar-payment-api",
+      error: "Database unavailable"
+    });
+  }
 });
 
 app.use("/api/create-payment", requireApiKeyAuth());


### PR DESCRIPTION
## What
Check Supabase connectivity before reporting the API as healthy.

## Why
Resolves #18
The health endpoint should confirm the database connection is live instead of always returning success.

## How
The `/health` route now performs a lightweight Supabase read against the `merchants` table before returning `200`. If the query fails or throws, the endpoint responds with `503` and a database-unavailable error payload.

## Testing
- `npm test` in `backend/`
- Verified backend test suite passes (25 tests)