### PR TITLE
feat(home): add getting started guide

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -14,23 +14,26 @@ export default function Home() {
 
       <section className="grid gap-6 rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur">
         <div className="flex flex-col gap-2">
-          <h2 className="text-lg font-semibold text-white">Next up for contributors</h2>
+          <h2 className="text-lg font-semibold text-white">Getting Started</h2>
           <p className="text-sm text-slate-300">
-            Create payment form, list recent payments, and connect status polling.
+            Follow these three steps to start accepting payments with Stellar links.
           </p>
         </div>
         <div className="grid gap-3 text-sm text-slate-200 sm:grid-cols-3">
           <div className="rounded-xl border border-white/10 bg-black/30 p-4">
-            <p className="font-mono text-xs text-glow">Issue 1</p>
-            <p className="mt-2">Build create-payment UI</p>
+            <p className="font-mono text-xs text-glow">Step 1</p>
+            <p className="mt-2 font-medium text-white">Register</p>
+            <p className="mt-1 text-slate-400">Create your merchant account to unlock the dashboard.</p>
           </div>
           <div className="rounded-xl border border-white/10 bg-black/30 p-4">
-            <p className="font-mono text-xs text-glow">Issue 2</p>
-            <p className="mt-2">Show payment status table</p>
+            <p className="font-mono text-xs text-glow">Step 2</p>
+            <p className="mt-2 font-medium text-white">Create Link</p>
+            <p className="mt-1 text-slate-400">Generate a payment link for the amount and asset you want to accept.</p>
           </div>
           <div className="rounded-xl border border-white/10 bg-black/30 p-4">
-            <p className="font-mono text-xs text-glow">Issue 3</p>
-            <p className="mt-2">Display QR codes</p>
+            <p className="font-mono text-xs text-glow">Step 3</p>
+            <p className="mt-2 font-medium text-white">Share</p>
+            <p className="mt-1 text-slate-400">Send the link to customers so they can pay instantly.</p>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## What
Add a small Getting Started section to the home page.

## Why
Resolves #36
The landing page should explain the three basic steps for accepting payments with the app.

## How
Replaced the contributor placeholder cards with a simple three-step guide that covers Register, Create Link, and Share while keeping the existing home page styling.

## Testing
- `npm run lint` in `frontend/`
- Blocked by pre-existing parsing errors in `src/app/layout.tsx` and `src/components/Navbar.tsx`