### PR TITLE
feat(fe): Add React Error Boundary around main content

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -634,7 +634,6 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -1154,7 +1153,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1685,7 +1683,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2363,7 +2360,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2533,7 +2529,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -3959,7 +3954,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4766,7 +4760,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4983,7 +4976,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4996,7 +4988,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5962,7 +5953,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6157,7 +6147,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import { Space_Grotesk, Space_Mono } from "next/font/google";
 import ThemeProvider from "@/components/ThemeProvider";
+import ErrorBoundary from "@/components/ErrorBoundary";
 import Navbar from "@/components/Navbar";
 
 const spaceGrotesk = Space_Grotesk({ subsets: ["latin"], variable: "--font-sans", display: "swap" });
@@ -17,12 +18,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className={`${spaceGrotesk.variable} ${spaceMono.variable} min-h-screen font-sans`}>
         <ThemeProvider>
           <Navbar />
-          {children}
+          <ErrorBoundary>
+            {children}
+          </ErrorBoundary>
         </ThemeProvider>
-    <html lang="en">
-      <body className={`${spaceGrotesk.variable} ${spaceMono.variable} min-h-screen font-sans`}>
-        <Navbar />
-        {children}
       </body>
     </html>
   );

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { Component, ErrorInfo, ReactNode } from "react";
+import Link from "next/link";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error("ErrorBoundary caught an error:", error, errorInfo);
+  }
+
+  handleReset = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <main className="flex min-h-screen flex-col items-center justify-center p-6 text-center">
+          <div className="flex flex-col items-center gap-8 max-w-md">
+            {/* Error Illustration */}
+            <div className="relative w-64 h-64">
+              <svg
+                viewBox="0 0 200 200"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                className="w-full h-full text-red-400"
+              >
+                <circle cx="100" cy="100" r="50" fill="currentColor" fillOpacity="0.2" />
+                <circle cx="100" cy="100" r="30" fill="currentColor" />
+                <g className="animate-pulse">
+                  <path
+                    d="M100 20L100 50M100 150L100 180M20 100L50 100M150 100L180 100"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                    strokeLinecap="round"
+                  />
+                  <path
+                    d="M43.4 43.4L64.6 64.6M135.4 135.4L156.6 156.6M43.4 156.6L64.6 135.4M135.4 43.4L156.6 64.6"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                    strokeLinecap="round"
+                  />
+                </g>
+                <path
+                  d="M80 80L120 120M120 80L80 120"
+                  stroke="white"
+                  strokeWidth="6"
+                  strokeLinecap="round"
+                />
+              </svg>
+              <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-40 h-40 bg-red-500/10 blur-3xl rounded-full" />
+            </div>
+
+            <div className="flex flex-col gap-3">
+              <p className="font-mono text-xs uppercase tracking-[0.3em] text-red-400">
+                Something Went Wrong
+              </p>
+              <h1 className="text-3xl font-bold text-white sm:text-4xl">
+                Houston, we have a problem.
+              </h1>
+              <p className="text-slate-400">
+                An unexpected error occurred while rendering this page. Please try again or return to the dashboard.
+              </p>
+            </div>
+
+            <div className="flex flex-col sm:flex-row gap-4">
+              <button
+                onClick={this.handleReset}
+                className="group relative flex items-center justify-center gap-2 rounded-full border border-mint/30 bg-mint/5 px-8 py-3 text-sm font-semibold text-mint backdrop-blur transition-all hover:bg-mint/10"
+              >
+                Try Again
+                <div className="absolute inset-0 -z-10 bg-mint/10 opacity-0 blur-xl transition-opacity group-hover:opacity-100" />
+              </button>
+
+              <Link
+                href="/"
+                className="flex items-center justify-center gap-2 rounded-full border border-white/10 bg-white/5 px-8 py-3 text-sm font-semibold text-white backdrop-blur transition-all hover:bg-white/10"
+              >
+                Back to Dashboard
+              </Link>
+            </div>
+          </div>
+        </main>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import ThemeToggle from "./ThemeToggle";
 
 export default function Navbar() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -19,7 +18,6 @@ export default function Navbar() {
 
   return (
     <nav className="border-b border-white/10 bg-black/50 backdrop-blur dark:border-white/10 dark:bg-black/50">
-    <nav className="border-b border-white/10 bg-black/50 backdrop-blur">
       <div className="mx-auto max-w-7xl px-6">
         <div className="flex h-16 items-center justify-between">
           {/* Logo */}


### PR DESCRIPTION
## Summary

Closes #30

This PR implements a React Error Boundary component that wraps the main page content in `layout.tsx`, preventing the entire app from crashing when a child component throws a rendering error.

## Changes

- **New file:** `frontend/src/components/ErrorBoundary.tsx` — A class-based React Error Boundary component with:
  - `getDerivedStateFromError` to catch rendering errors
  - `componentDidCatch` for error logging
  - A friendly "Something went wrong" fallback UI with "Try Again" and "Back to Dashboard" actions
  - Fallback design matches existing error/not-found page aesthetics (SVG illustration, red accents, mint buttons)
- **Modified:** `frontend/src/app/layout.tsx` — Wrapped `{children}` with `<ErrorBoundary>` inside `<ThemeProvider>` so the boundary has access to theme context
- **Fixed:** Duplicate `<html>`/`<body>` tags in `layout.tsx` (pre-existing issue)
- **Fixed:** Duplicate `<nav>` tags and unused `ThemeToggle` import in `Navbar.tsx` (pre-existing issue)

## How It Works

When any component inside the main content area throws during rendering, the Error Boundary catches it and displays a user-friendly fallback instead of a blank/crashed page. Users can retry or navigate back to the dashboard.

## Testing

- `next build` — compiles successfully
- `next lint` — zero warnings or errors
