### PR TITLE
feat: add input sanitization middleware for metadata payloads

### DIFF
--- a/backend/src/lib/sanitize-metadata.js
+++ b/backend/src/lib/sanitize-metadata.js
@@ -1,0 +1,177 @@
+/**
+ * Middleware to sanitize metadata JSON payloads
+ * Prevents XSS, NoSQL injection, and excessive nesting
+ */
+
+const MAX_NESTING_DEPTH = 4;
+const MAX_STRING_LENGTH = 1000;
+const MAX_KEYS = 50;
+
+// Patterns that indicate potential XSS or injection attacks
+const DANGEROUS_PATTERNS = [
+  /<script[^>]*>.*?<\/script>/gi,
+  /javascript:/gi,
+  /on\w+\s*=/gi, // event handlers like onclick=
+  /\$where/gi, // MongoDB injection
+  /\$ne/gi,
+  /\$gt/gi,
+  /\$lt/gi,
+  /\$regex/gi,
+];
+
+/**
+ * Check nesting depth of an object
+ */
+function getDepth(obj, currentDepth = 0) {
+  if (typeof obj !== 'object' || obj === null) {
+    return currentDepth;
+  }
+
+  if (Array.isArray(obj)) {
+    if (obj.length === 0) return currentDepth + 1;
+    return Math.max(...obj.map(item => getDepth(item, currentDepth + 1)));
+  }
+
+  const keys = Object.keys(obj);
+  if (keys.length === 0) return currentDepth + 1;
+
+  return Math.max(...keys.map(key => getDepth(obj[key], currentDepth + 1)));
+}
+
+/**
+ * Count total keys in nested object
+ */
+function countKeys(obj) {
+  if (typeof obj !== 'object' || obj === null) {
+    return 0;
+  }
+
+  let count = 0;
+
+  if (Array.isArray(obj)) {
+    for (const item of obj) {
+      count += countKeys(item);
+    }
+    return count;
+  }
+
+  const keys = Object.keys(obj);
+  count += keys.length;
+
+  for (const key of keys) {
+    count += countKeys(obj[key]);
+  }
+
+  return count;
+}
+
+/**
+ * Sanitize string values to remove dangerous patterns
+ */
+function sanitizeString(str) {
+  if (typeof str !== 'string') return str;
+
+  // Truncate overly long strings
+  if (str.length > MAX_STRING_LENGTH) {
+    str = str.substring(0, MAX_STRING_LENGTH);
+  }
+
+  // Remove dangerous patterns
+  let sanitized = str;
+  for (const pattern of DANGEROUS_PATTERNS) {
+    sanitized = sanitized.replace(pattern, '');
+  }
+
+  // HTML encode special characters
+  sanitized = sanitized
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;')
+    .replace(/\//g, '&#x2F;');
+
+  return sanitized;
+}
+
+/**
+ * Recursively sanitize object
+ */
+function sanitizeObject(obj) {
+  if (typeof obj !== 'object' || obj === null) {
+    return typeof obj === 'string' ? sanitizeString(obj) : obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(item => sanitizeObject(item));
+  }
+
+  const sanitized = {};
+  for (const [key, value] of Object.entries(obj)) {
+    // Sanitize key names too
+    const cleanKey = sanitizeString(key);
+    sanitized[cleanKey] = sanitizeObject(value);
+  }
+
+  return sanitized;
+}
+
+/**
+ * Validate and sanitize metadata
+ */
+export function validateMetadata(metadata) {
+  // Allow null/undefined
+  if (metadata === null || metadata === undefined) {
+    return { valid: true, sanitized: null };
+  }
+
+  // Must be an object or array
+  if (typeof metadata !== 'object') {
+    return {
+      valid: false,
+      error: 'Metadata must be a JSON object or array'
+    };
+  }
+
+  // Check nesting depth
+  const depth = getDepth(metadata);
+  if (depth > MAX_NESTING_DEPTH) {
+    return {
+      valid: false,
+      error: `Metadata nesting depth exceeds maximum of ${MAX_NESTING_DEPTH} levels`
+    };
+  }
+
+  // Check total keys
+  const keyCount = countKeys(metadata);
+  if (keyCount > MAX_KEYS) {
+    return {
+      valid: false,
+      error: `Metadata contains too many keys (max: ${MAX_KEYS})`
+    };
+  }
+
+  // Sanitize the metadata
+  const sanitized = sanitizeObject(metadata);
+
+  return { valid: true, sanitized };
+}
+
+/**
+ * Express middleware for sanitizing metadata in request body
+ */
+export function sanitizeMetadataMiddleware(req, res, next) {
+  if (!req.body.metadata) {
+    return next();
+  }
+
+  const result = validateMetadata(req.body.metadata);
+
+  if (!result.valid) {
+    return res.status(400).json({ error: result.error });
+  }
+
+  // Replace with sanitized version
+  req.body.metadata = result.sanitized;
+  next();
+}

--- a/backend/src/lib/sanitize-metadata.test.js
+++ b/backend/src/lib/sanitize-metadata.test.js
@@ -1,0 +1,233 @@
+import { describe, it, expect } from 'vitest'
+import { validateMetadata, sanitizeMetadataMiddleware } from './sanitize-metadata.js'
+
+describe('validateMetadata', () => {
+  it('allows null metadata', () => {
+    const result = validateMetadata(null)
+    expect(result.valid).toBe(true)
+    expect(result.sanitized).toBe(null)
+  })
+
+  it('allows undefined metadata', () => {
+    const result = validateMetadata(undefined)
+    expect(result.valid).toBe(true)
+    expect(result.sanitized).toBe(null)
+  })
+
+  it('allows simple valid object', () => {
+    const metadata = { orderId: '12345', customerName: 'John' }
+    const result = validateMetadata(metadata)
+    expect(result.valid).toBe(true)
+    expect(result.sanitized).toHaveProperty('orderId')
+  })
+
+  it('rejects non-object metadata', () => {
+    const result = validateMetadata('string')
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain('must be a JSON object')
+  })
+
+  it('rejects nesting deeper than 4 levels', () => {
+    const metadata = {
+      level1: {
+        level2: {
+          level3: {
+            level4: {
+              level5: 'too deep'
+            }
+          }
+        }
+      }
+    }
+    const result = validateMetadata(metadata)
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain('nesting depth exceeds')
+  })
+
+  it('allows nesting up to 4 levels', () => {
+    const metadata = {
+      level1: {
+        level2: {
+          level3: {
+            level4: 'ok'
+          }
+        }
+      }
+    }
+    const result = validateMetadata(metadata)
+    expect(result.valid).toBe(true)
+  })
+
+  it('removes XSS script tags', () => {
+    const metadata = {
+      description: '<script>alert("xss")</script>Hello'
+    }
+    const result = validateMetadata(metadata)
+    expect(result.valid).toBe(true)
+    expect(result.sanitized.description).not.toContain('<script>')
+    expect(result.sanitized.description).not.toContain('alert')
+  })
+
+  it('removes javascript: protocol', () => {
+    const metadata = {
+      link: 'javascript:alert(1)'
+    }
+    const result = validateMetadata(metadata)
+    expect(result.valid).toBe(true)
+    expect(result.sanitized.link).not.toContain('javascript:')
+  })
+
+  it('removes event handlers', () => {
+    const metadata = {
+      html: '<img src=x onerror=alert(1)>'
+    }
+    const result = validateMetadata(metadata)
+    expect(result.valid).toBe(true)
+    expect(result.sanitized.html).not.toContain('onerror=')
+  })
+
+  it('removes NoSQL injection patterns ($where)', () => {
+    const metadata = {
+      query: { $where: 'this.password == "test"' }
+    }
+    const result = validateMetadata(metadata)
+    expect(result.valid).toBe(true)
+    const sanitized = JSON.stringify(result.sanitized)
+    expect(sanitized).not.toContain('$where')
+  })
+
+  it('removes NoSQL injection patterns ($ne, $gt, $lt)', () => {
+    const metadata = {
+      filter: { price: { $gt: 0, $lt: 100, $ne: 50 } }
+    }
+    const result = validateMetadata(metadata)
+    expect(result.valid).toBe(true)
+    const sanitized = JSON.stringify(result.sanitized)
+    expect(sanitized).not.toContain('$gt')
+    expect(sanitized).not.toContain('$lt')
+    expect(sanitized).not.toContain('$ne')
+  })
+
+  it('HTML encodes special characters', () => {
+    const metadata = {
+      text: '<div>"Hello" & \'World\'</div>'
+    }
+    const result = validateMetadata(metadata)
+    expect(result.valid).toBe(true)
+    expect(result.sanitized.text).toContain('&lt;')
+    expect(result.sanitized.text).toContain('&gt;')
+    expect(result.sanitized.text).toContain('&quot;')
+    expect(result.sanitized.text).toContain('&#x27;')
+    expect(result.sanitized.text).toContain('&amp;')
+  })
+
+  it('truncates overly long strings', () => {
+    const longString = 'a'.repeat(2000)
+    const metadata = { description: longString }
+    const result = validateMetadata(metadata)
+    expect(result.valid).toBe(true)
+    expect(result.sanitized.description.length).toBeLessThanOrEqual(1000)
+  })
+
+  it('rejects metadata with too many keys', () => {
+    const metadata = {}
+    for (let i = 0; i < 60; i++) {
+      metadata[`key${i}`] = 'value'
+    }
+    const result = validateMetadata(metadata)
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain('too many keys')
+  })
+
+  it('sanitizes nested arrays', () => {
+    const metadata = {
+      items: [
+        { name: '<script>xss</script>Product' },
+        { name: 'Normal Product' }
+      ]
+    }
+    const result = validateMetadata(metadata)
+    expect(result.valid).toBe(true)
+    expect(result.sanitized.items[0].name).not.toContain('<script>')
+  })
+
+  it('sanitizes key names', () => {
+    const metadata = {
+      '<script>key</script>': 'value'
+    }
+    const result = validateMetadata(metadata)
+    expect(result.valid).toBe(true)
+    const keys = Object.keys(result.sanitized)
+    expect(keys[0]).not.toContain('<script>')
+  })
+
+  it('handles mixed valid and malicious content', () => {
+    const metadata = {
+      orderId: '12345',
+      customerName: 'John Doe',
+      notes: '<script>alert("xss")</script>Important note',
+      tags: ['tag1', 'javascript:void(0)', 'tag3']
+    }
+    const result = validateMetadata(metadata)
+    expect(result.valid).toBe(true)
+    expect(result.sanitized.orderId).toBe('12345')
+    expect(result.sanitized.customerName).toContain('John')
+    expect(result.sanitized.notes).not.toContain('<script>')
+    expect(result.sanitized.tags[1]).not.toContain('javascript:')
+  })
+})
+
+describe('sanitizeMetadataMiddleware', () => {
+  it('passes through when no metadata in request', () => {
+    const req = { body: {} }
+    const res = {}
+    let nextCalled = false
+    const next = () => { nextCalled = true }
+
+    sanitizeMetadataMiddleware(req, res, next)
+
+    expect(nextCalled).toBe(true)
+  })
+
+  it('sanitizes valid metadata and calls next', () => {
+    const req = {
+      body: {
+        metadata: { orderId: '123', note: '<script>xss</script>' }
+      }
+    }
+    const res = {}
+    let nextCalled = false
+    const next = () => { nextCalled = true }
+
+    sanitizeMetadataMiddleware(req, res, next)
+
+    expect(nextCalled).toBe(true)
+    expect(req.body.metadata.note).not.toContain('<script>')
+  })
+
+  it('returns 400 for invalid metadata', () => {
+    const req = {
+      body: {
+        metadata: {
+          level1: { level2: { level3: { level4: { level5: 'too deep' } } } }
+        }
+      }
+    }
+    let statusCode
+    let responseBody
+    const res = {
+      status: (code) => {
+        statusCode = code
+        return {
+          json: (body) => { responseBody = body }
+        }
+      }
+    }
+    const next = () => {}
+
+    sanitizeMetadataMiddleware(req, res, next)
+
+    expect(statusCode).toBe(400)
+    expect(responseBody.error).toContain('nesting depth')
+  })
+})

--- a/backend/src/routes/payments.js
+++ b/backend/src/routes/payments.js
@@ -4,6 +4,7 @@ import { randomUUID } from "node:crypto";
 import { supabase } from "../lib/supabase.js";
 import { findMatchingPayment } from "../lib/stellar.js";
 import { sendWebhook } from "../lib/webhooks.js";
+import { sanitizeMetadataMiddleware } from "../lib/sanitize-metadata.js";
 import rateLimit from "express-rate-limit";
 
 const router = express.Router();
@@ -106,7 +107,7 @@ function validateCreatePayment(body) {
  *       400:
  *         description: Validation error
  */
-router.post("/create-payment", async (req, res, next) => {
+router.post("/create-payment", sanitizeMetadataMiddleware, async (req, res, next) => {
   try {
     const error = validateCreatePayment(req.body || {});
     if (error) {


### PR DESCRIPTION
- Prevent XSS attacks (script tags, javascript:, event handlers)
- Prevent NoSQL injection ($where, $ne, $gt, $lt, $regex)
- HTML encode special characters
- Reject deep nesting (>4 levels)
- Reject excessive keys (>50 total)
- Truncate long strings (>1000 chars)
- Applied to POST /api/create-payment endpoint
- 20 comprehensive tests, all passing (45/45 total)

Resolves: #84 - Input sanitization middleware
Security: Protects against XSS and NoSQL injection in metadata field