### PR TITLE
feat: secure password hashing for merchant dashboards

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.49.1",
+        "bcryptjs": "^3.0.3",
         "cors": "^2.8.6",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
@@ -1263,6 +1264,15 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
     },
     "node_modules/bignumber.js": {
       "version": "9.3.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.49.1",
+    "bcryptjs": "^3.0.3",
     "cors": "^2.8.6",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",

--- a/backend/src/lib/auth.js
+++ b/backend/src/lib/auth.js
@@ -1,3 +1,26 @@
+import bcrypt from "bcryptjs";
+
+const SALT_ROUNDS = 12;
+
+/**
+ * Hash a plain-text merchant password with bcrypt.
+ * @param {string} plaintext
+ * @returns {Promise<string>} bcrypt hash
+ */
+export async function hashPassword(plaintext) {
+  return bcrypt.hash(plaintext, SALT_ROUNDS);
+}
+
+/**
+ * Verify a plain-text password against a stored bcrypt hash.
+ * @param {string} plaintext
+ * @param {string} hash
+ * @returns {Promise<boolean>}
+ */
+export async function verifyPassword(plaintext, hash) {
+  return bcrypt.compare(plaintext, hash);
+}
+
 export function createApiKeyAuth({ supabaseClient = null } = {}) {
   return async function requireApiKeyAuth(req, res, next) {
     try {

--- a/backend/src/lib/auth.test.js
+++ b/backend/src/lib/auth.test.js
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createApiKeyAuth } from "./auth.js";
+import { createApiKeyAuth, hashPassword, verifyPassword } from "./auth.js";
 
 function createResponse() {
   return {
@@ -15,6 +15,30 @@ function createRequest(headers = {}) {
     }
   };
 }
+
+describe("hashPassword / verifyPassword", () => {
+  it("produces a bcrypt hash distinct from the plaintext", async () => {
+    const hash = await hashPassword("s3cr3t!");
+    expect(hash).not.toBe("s3cr3t!");
+    expect(hash).toMatch(/^\$2[ab]\$/);
+  });
+
+  it("verifyPassword returns true for the correct password", async () => {
+    const hash = await hashPassword("correct-horse");
+    expect(await verifyPassword("correct-horse", hash)).toBe(true);
+  });
+
+  it("verifyPassword returns false for a wrong password", async () => {
+    const hash = await hashPassword("correct-horse");
+    expect(await verifyPassword("wrong-password", hash)).toBe(false);
+  });
+
+  it("two hashes of the same password differ (unique salts)", async () => {
+    const h1 = await hashPassword("same");
+    const h2 = await hashPassword("same");
+    expect(h1).not.toBe(h2);
+  });
+});
 
 describe("createApiKeyAuth", () => {
   let maybeSingle;


### PR DESCRIPTION
## Summary
- Installed `bcryptjs` (pure-JS bcrypt, no native bindings required)
- Added `hashPassword(plaintext)` — bcrypt-hashes a plain-text password with 12 salt rounds
- Added `verifyPassword(plaintext, hash)` — constant-time comparison against a stored hash
- Both functions are exported from `backend/src/lib/auth.js` for use in merchant registration/login flows
- Added 4 unit tests covering hash format, correct-password verification, wrong-password rejection, and unique-salt generation

## Test plan
- [ ] `npm test` — all 29 tests pass (4 new bcrypt tests + 25 existing)

Closes #48