### PR TITLE
feat: add trusted Stellar addresses for merchants

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3923,10 +3923,6 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.11",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.11.tgz",
-      "integrity": "sha512-DAKrHphkJyiGuau/cFieRYhcTFeK/lBuD++C7cZ6KZHbMhBrisoi+EvhQ5RZrIfV5qwsW8kgQ07JIC+MDJRAhg==",
-      "dev": true,
       "version": "2.10.7",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.7.tgz",
       "integrity": "sha512-1ghYO3HnxGec0TCGBXiDLVns4eCSx4zJpxnHrlqFQajmhfKMQBzUGDdkMK7fUW7PTHTeLf+j87aTuKuuwWzMGw==",
@@ -4654,10 +4650,6 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.325",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.325.tgz",
-      "integrity": "sha512-PwfIw7WQSt3xX7yOf5OE/unLzsK9CaN2f/FvV3WjPR1Knoc1T9vePRVV4W1EM301JzzysK51K7FNKcusCr0zYA==",
-      "dev": true,
       "version": "1.5.313",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz",
       "integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -9,6 +9,9 @@ import {
   useMerchantApiKey,
   useMerchantHydrated,
   useSetMerchantApiKey,
+  useMerchantTrustedAddresses,
+  useAddTrustedAddress,
+  useRemoveTrustedAddress,
 } from "@/lib/merchant-store";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000";
@@ -19,7 +22,7 @@ const DEFAULT_BRANDING = {
   background_color: "#050608",
 };
 
-type SettingsTab = "api" | "branding";
+type SettingsTab = "api" | "branding" | "addresses";
 
 function normalizeHexInput(value: string) {
   const trimmed = value.trim();
@@ -116,6 +119,9 @@ export default function SettingsPage() {
   const apiKey = useMerchantApiKey();
   const hydrated = useMerchantHydrated();
   const setApiKey = useSetMerchantApiKey();
+  const trustedAddresses = useMerchantTrustedAddresses();
+  const addTrustedAddress = useAddTrustedAddress();
+  const removeTrustedAddress = useRemoveTrustedAddress();
 
   const [revealed, setRevealed] = useState(false);
 
@@ -128,6 +134,12 @@ export default function SettingsPage() {
   const [brandingError, setBrandingError] = useState<string | null>(null);
   const [loadingBranding, setLoadingBranding] = useState(false);
   const [savingBranding, setSavingBranding] = useState(false);
+
+  // Trusted addresses state
+  const [addressLabel, setAddressLabel] = useState("");
+  const [addressValue, setAddressValue] = useState("");
+  const [addressError, setAddressError] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
 
   useHydrateMerchantStore();
 
@@ -238,6 +250,43 @@ export default function SettingsPage() {
     }
   };
 
+  const STELLAR_ADDRESS_RE = /^G[A-Z2-7]{55}$/;
+
+  const addAddress = () => {
+    setAddressError(null);
+
+    if (!addressLabel.trim()) {
+      setAddressError("Label is required");
+      return;
+    }
+
+    if (!STELLAR_ADDRESS_RE.test(addressValue.trim())) {
+      setAddressError(
+        "Address must be a valid Stellar public key (56 characters, starts with G).",
+      );
+      return;
+    }
+
+    const newAddress = {
+      id: `addr_${Date.now()}`,
+      label: addressLabel.trim(),
+      address: addressValue.trim(),
+      created_at: new Date().toISOString(),
+    };
+
+    addTrustedAddress(newAddress);
+    setAddressLabel("");
+    setAddressValue("");
+    toast.success("Address added to trusted addresses");
+  };
+
+  const removeAddress = (id: string) => {
+    setDeletingId(id);
+    removeTrustedAddress(id);
+    setDeletingId(null);
+    toast.success("Address removed");
+  };
+
   // ── Await hydration ──────────────────────────────────────────────────────
   if (!hydrated) return null;
 
@@ -320,6 +369,17 @@ export default function SettingsPage() {
             }`}
           >
             Branding
+          </button>
+          <button
+            type="button"
+            onClick={() => setActiveTab("addresses")}
+            className={`flex-1 rounded-lg px-4 py-2 text-sm font-medium ${
+              activeTab === "addresses"
+                ? "bg-white text-black"
+                : "text-slate-300 hover:bg-white/10"
+            }`}
+          >
+            Trusted Addresses
           </button>
         </div>
 
@@ -526,6 +586,122 @@ export default function SettingsPage() {
             >
               {savingBranding ? "Saving..." : loadingBranding ? "Loading..." : "Save Branding"}
             </button>
+          </section>
+        )}
+
+        {activeTab === "addresses" && (
+          <section className="flex flex-col gap-5">
+            <div className="flex flex-col gap-1">
+              <h2 className="text-xs font-medium uppercase tracking-wider text-slate-400">
+                Trusted Addresses
+              </h2>
+              <p className="text-sm text-slate-500">
+                Save frequently used Stellar addresses for quick access when creating payments.
+              </p>
+            </div>
+
+            {addressError && (
+              <div className="rounded-xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-300">
+                {addressError}
+              </div>
+            )}
+
+            {/* Add new address form */}
+            <div className="rounded-xl border border-white/10 bg-white/5 p-4">
+              <p className="mb-3 text-xs font-medium uppercase tracking-wider text-slate-400">
+                Add New Address
+              </p>
+              <div className="flex flex-col gap-3">
+                <div className="flex flex-col gap-1.5">
+                  <label htmlFor="address-label" className="text-xs text-slate-400">
+                    Label
+                  </label>
+                  <input
+                    id="address-label"
+                    type="text"
+                    value={addressLabel}
+                    onChange={(e) => setAddressLabel(e.target.value)}
+                    className="rounded-xl border border-white/10 bg-black/40 p-2.5 text-sm text-white placeholder:text-slate-600 focus:border-mint/50 focus:outline-none focus:ring-1 focus:ring-mint/50"
+                    placeholder="e.g. Main Wallet, Supplier ABC"
+                  />
+                </div>
+                <div className="flex flex-col gap-1.5">
+                  <label htmlFor="address-value" className="text-xs text-slate-400">
+                    Stellar Address
+                  </label>
+                  <input
+                    id="address-value"
+                    type="text"
+                    value={addressValue}
+                    onChange={(e) => setAddressValue(e.target.value)}
+                    className="rounded-xl border border-white/10 bg-black/40 p-2.5 font-mono text-sm text-white placeholder:font-sans placeholder:text-slate-600 focus:border-mint/50 focus:outline-none focus:ring-1 focus:ring-mint/50"
+                    placeholder="GABC...XYZ (56 characters)"
+                    autoComplete="off"
+                    spellCheck={false}
+                  />
+                </div>
+                <button
+                  type="button"
+                  onClick={addAddress}
+                  className="mt-1 flex h-10 items-center justify-center rounded-xl bg-mint font-semibold text-black transition-all hover:bg-glow"
+                >
+                  Add Address
+                </button>
+              </div>
+            </div>
+
+            {/* Saved addresses list */}
+            <div className="flex flex-col gap-3">
+              <h3 className="text-xs font-medium uppercase tracking-wider text-slate-400">
+                Saved Addresses ({trustedAddresses.length})
+              </h3>
+              
+              {trustedAddresses.length === 0 ? (
+                <div className="rounded-xl border border-white/10 bg-white/5 p-6 text-center">
+                  <p className="text-sm text-slate-400">
+                    No trusted addresses saved yet. Add your first address above.
+                  </p>
+                </div>
+              ) : (
+                <div className="flex flex-col gap-2">
+                  {trustedAddresses.map((addr) => (
+                    <div
+                      key={addr.id}
+                      className="flex items-center justify-between gap-3 rounded-xl border border-white/10 bg-white/5 p-3"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-medium text-white">
+                          {addr.label}
+                        </p>
+                        <p className="truncate font-mono text-xs text-slate-500">
+                          {addr.address.slice(0, 12)}...{addr.address.slice(-8)}
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            navigator.clipboard.writeText(addr.address);
+                            toast.success("Address copied to clipboard");
+                          }}
+                          className="rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-medium text-slate-300 transition-all hover:bg-white/10 hover:text-white"
+                        >
+                          Copy
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => removeAddress(addr.id)}
+                          disabled={deletingId === addr.id}
+                          className="rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-1.5 text-xs font-medium text-red-400 transition-all hover:border-red-500/50 hover:bg-red-500/20 disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          {deletingId === addr.id ? "Removing..." : "Delete"}
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
           </section>
         )}
       </div>

--- a/frontend/src/components/CreatePaymentForm.tsx
+++ b/frontend/src/components/CreatePaymentForm.tsx
@@ -8,6 +8,7 @@ import {
   useHydrateMerchantStore,
   useMerchantApiKey,
   useMerchantHydrated,
+  useMerchantTrustedAddresses,
 } from "@/lib/merchant-store";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000";
@@ -47,8 +48,10 @@ export default function CreatePaymentForm() {
   const [created, setCreated] = useState<CreatedPayment | null>(null);
   const [useSessionBranding, setUseSessionBranding] = useState(false);
   const [branding, setBranding] = useState(DEFAULT_BRANDING);
+  const [selectedTrustedAddress, setSelectedTrustedAddress] = useState<string>("");
   const apiKey = useMerchantApiKey();
   const hydrated = useMerchantHydrated();
+  const trustedAddresses = useMerchantTrustedAddresses();
 
   useHydrateMerchantStore();
 
@@ -122,7 +125,18 @@ export default function CreatePaymentForm() {
     setAsset("XLM");
     setUseSessionBranding(false);
     setBranding(DEFAULT_BRANDING);
+    setSelectedTrustedAddress("");
     setError(null);
+  };
+
+  const handleTrustedAddressSelect = (addressId: string) => {
+    setSelectedTrustedAddress(addressId);
+    if (addressId) {
+      const selected = trustedAddresses.find((addr) => addr.id === addressId);
+      if (selected) {
+        setRecipient(selected.address);
+      }
+    }
   };
 
   const updateBrandingField = (
@@ -283,6 +297,31 @@ export default function CreatePaymentForm() {
             </p>
           )}
         </div>
+
+        {/* Trusted Addresses Dropdown */}
+        {trustedAddresses.length > 0 && (
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="trusted-address"
+              className="text-xs font-medium uppercase tracking-wider text-slate-400"
+            >
+              Select from Trusted Addresses
+            </label>
+            <select
+              id="trusted-address"
+              value={selectedTrustedAddress}
+              onChange={(e) => handleTrustedAddressSelect(e.target.value)}
+              className="rounded-xl border border-white/10 bg-white/5 p-3 text-sm text-white focus:border-mint/50 focus:outline-none focus:ring-1 focus:ring-mint/50"
+            >
+              <option value="">-- Select a saved address --</option>
+              {trustedAddresses.map((addr) => (
+                <option key={addr.id} value={addr.id}>
+                  {addr.label} ({addr.address.slice(0, 8)}...{addr.address.slice(-6)})
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
 
         {/* Recipient */}
         <div className="flex flex-col gap-1.5">

--- a/frontend/src/lib/merchant-store.ts
+++ b/frontend/src/lib/merchant-store.ts
@@ -13,6 +13,13 @@ export interface MerchantSession {
   exp: number;
 }
 
+export interface TrustedAddress {
+  id: string;
+  label: string;
+  address: string;
+  created_at: string;
+}
+
 export interface MerchantMetadata {
   id: string;
   email: string;
@@ -25,6 +32,7 @@ export interface MerchantMetadata {
     secondary_color?: string;
     background_color?: string;
   } | null;
+  trusted_addresses?: TrustedAddress[] | null;
   created_at: string;
 }
 
@@ -38,6 +46,8 @@ interface MerchantStore {
   setToken: (token: string | null) => void;
   setApiKey: (apiKey: string | null) => void;
   setMerchant: (merchant: MerchantMetadata | null) => void;
+  addTrustedAddress: (address: TrustedAddress) => void;
+  removeTrustedAddress: (id: string) => void;
   logout: () => void;
 }
 
@@ -150,6 +160,46 @@ export const useMerchantStore = create<MerchantStore>((set) => ({
     set({ merchant });
   },
 
+  addTrustedAddress: (address) => {
+    set((state) => {
+      if (!state.merchant) return state;
+      
+      const currentAddresses = state.merchant.trusted_addresses || [];
+      const updatedAddresses = [...currentAddresses, address];
+      
+      const updatedMerchant = {
+        ...state.merchant,
+        trusted_addresses: updatedAddresses,
+      };
+      
+      if (typeof window !== "undefined") {
+        localStorage.setItem(MERCHANT_KEY, JSON.stringify(updatedMerchant));
+      }
+      
+      return { merchant: updatedMerchant };
+    });
+  },
+
+  removeTrustedAddress: (id) => {
+    set((state) => {
+      if (!state.merchant) return state;
+      
+      const currentAddresses = state.merchant.trusted_addresses || [];
+      const updatedAddresses = currentAddresses.filter((addr) => addr.id !== id);
+      
+      const updatedMerchant = {
+        ...state.merchant,
+        trusted_addresses: updatedAddresses,
+      };
+      
+      if (typeof window !== "undefined") {
+        localStorage.setItem(MERCHANT_KEY, JSON.stringify(updatedMerchant));
+      }
+      
+      return { merchant: updatedMerchant };
+    });
+  },
+
   logout: () => {
     if (typeof window !== "undefined") {
       localStorage.removeItem(TOKEN_KEY);
@@ -196,4 +246,16 @@ export function useSetMerchantMetadata() {
 
 export function useMerchantLogout() {
   return useMerchantStore((state) => state.logout);
+}
+
+export function useMerchantTrustedAddresses() {
+  return useMerchantStore((state) => state.merchant?.trusted_addresses || []);
+}
+
+export function useAddTrustedAddress() {
+  return useMerchantStore((state) => state.addTrustedAddress);
+}
+
+export function useRemoveTrustedAddress() {
+  return useMerchantStore((state) => state.removeTrustedAddress);
 }


### PR DESCRIPTION
- Add TrustedAddress type and state management in merchant-store
- Add Trusted Addresses tab in Settings page with CRUD functionality
- Add dropdown selector in Create Payment form to select saved addresses
- Validate Stellar address format (G + 55 base32 chars)
- Persist trusted addresses in localStorage
- Copy and delete actions for saved addresses

Closes #183