### PR TITLE
refactor: implement Application Factory Pattern (app.js + server.js)

### DIFF
--- a/backend/output.txt
+++ b/backend/output.txt
@@ -1,0 +1,17 @@
+C:\Users\USER\OneDrive\Desktop\Open Source Projects\Stellar_Payment_API\backend
+├── Dockerfile
+├── package-lock.json
+├── package.json
+├── scripts
+|  └── purge-webhook-logs.js
+├── sql
+|  ├── 20260326_log_retention_pg_cron.sql
+|  ├── migrations
+|  └── schema.sql
+└── src
+   ├── index.js
+   ├── lib
+   └── routes
+
+directory: 6 file: 7
+

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -494,6 +494,7 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.11.0.tgz",
       "integrity": "sha512-GHoprlNQD51Xq2Ztd94HHV94MdFZQ3CVrpA04Fz8MVoHM0B7SlbmPEVIjwTbcv58z8QyjnrOuikS0rWF03k5dQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -1921,6 +1922,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -1967,6 +1969,7 @@
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
       "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ip-address": "10.1.0"
       },
@@ -2870,6 +2873,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -3776,6 +3780,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "nodemon src/index.js",
-    "start": "node src/index.js",
+    "dev": "nodemon src/server.js",
+    "start": "node src/server.js",
     "test": "vitest run",
     "purge:webhook-logs": "node scripts/purge-webhook-logs.js"
   },

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,0 +1,125 @@
+import cors from "cors";
+import express from "express";
+import morgan from "morgan";
+import swaggerJsdoc from "swagger-jsdoc";
+import swaggerUi from "swagger-ui-express";
+import { ZodError } from "zod";
+
+import createPaymentsRouter from "./routes/payments.js";
+import merchantsRouter from "./routes/merchants.js";
+import metricsRouter from "./routes/metrics.js";
+
+import { requireApiKeyAuth } from "./lib/auth.js";
+import { isHorizonReachable } from "./lib/stellar.js";
+import { supabase } from "./lib/supabase.js";
+import { pool } from "./lib/db.js";
+import { formatZodError } from "./lib/request-schemas.js";
+import { idempotencyMiddleware } from "./lib/idempotency.js";
+import {
+  createRedisRateLimitStore,
+  createVerifyPaymentRateLimit,
+} from "./lib/rate-limit.js";
+
+export async function createApp({ redisClient }) {
+  const app = express();
+
+  // Make DB pool accessible
+  app.locals.pool = pool;
+
+  const port = process.env.PORT || 4000;
+
+  const swaggerSpec = swaggerJsdoc({
+    definition: {
+      openapi: "3.0.0",
+      info: {
+        title: "Stellar Payment API",
+        version: "0.1.0",
+        description: "API for creating and verifying Stellar network payments",
+      },
+      servers: [{ url: `http://localhost:${port}` }],
+    },
+    apis: ["./src/routes/*.js"],
+  });
+
+  app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+
+  const allowedOrigins = process.env.CORS_ALLOWED_ORIGINS
+    ? process.env.CORS_ALLOWED_ORIGINS.split(",").map((o) => o.trim())
+    : ["http://localhost:3000"];
+
+  app.use(
+    cors({
+      origin: (origin, callback) => {
+        if (!origin) return callback(null, true);
+        if (allowedOrigins.includes(origin)) return callback(null, true);
+        callback(new Error("Not allowed by CORS"));
+      },
+      credentials: true,
+    }),
+  );
+
+  app.use(express.json({ limit: "1mb" }));
+  app.use(morgan("dev"));
+
+  // Health check
+  app.get("/health", async (req, res) => {
+    try {
+      const [dbResult, horizonReachable] = await Promise.all([
+        supabase.from("merchants").select("id").limit(1),
+        isHorizonReachable(),
+      ]);
+
+      if (dbResult.error) {
+        return res.status(503).json({
+          ok: false,
+          error: "Database unavailable",
+          horizon_reachable: horizonReachable,
+        });
+      }
+
+      if (!horizonReachable) {
+        return res.status(503).json({
+          ok: false,
+          error: "Horizon unavailable",
+          horizon_reachable: false,
+        });
+      }
+
+      res.json({ ok: true, horizon_reachable: true });
+    } catch {
+      res.status(503).json({
+        ok: false,
+        error: "Health check failed",
+        horizon_reachable: false,
+      });
+    }
+  });
+
+  const verifyPaymentRateLimit = createVerifyPaymentRateLimit({
+    store: createRedisRateLimitStore({ client: redisClient }),
+  });
+
+  app.use("/api/create-payment", requireApiKeyAuth());
+  app.use("/api/create-payment", idempotencyMiddleware);
+  app.use("/api/sessions", requireApiKeyAuth());
+  app.use("/api/sessions", idempotencyMiddleware);
+  app.use("/api/payments", requireApiKeyAuth());
+  app.use("/api/rotate-key", requireApiKeyAuth());
+  app.use("/api/merchant-branding", requireApiKeyAuth());
+
+  app.use("/api", createPaymentsRouter({ verifyPaymentRateLimit }));
+  app.use("/api", merchantsRouter);
+  app.use("/api", metricsRouter);
+
+  app.use((err, req, res, next) => {
+    if (err instanceof ZodError) {
+      return res.status(400).json({ error: formatZodError(err) });
+    }
+
+    res.status(err.status || 500).json({
+      error: err.message || "Internal Server Error",
+    });
+  });
+
+  return app;
+}

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,0 +1,41 @@
+import "dotenv/config";
+import { createApp } from "./app.js";
+import { connectRedisClient, closeRedisClient } from "./lib/redis.js";
+import { closePool, pool } from "./lib/db.js";
+import { validateEnvironmentVariables } from "./lib/env-validation.js";
+
+validateEnvironmentVariables();
+
+const port = process.env.PORT || 4000;
+
+async function startServer() {
+  const redisClient = await connectRedisClient();
+
+  const app = await createApp({ redisClient });
+
+  // Probe DB
+  try {
+    await pool.query("SELECT 1");
+    console.log("✅ pg pool connected");
+  } catch (err) {
+    console.warn("⚠️ pg pool probe failed:", err.message);
+  }
+
+  const server = app.listen(port, () => {
+    console.log(`API listening on http://localhost:${port}`);
+  });
+
+  function shutdown(signal) {
+    console.log(`${signal} received — shutting down...`);
+    server.close(async () => {
+      await closePool();
+      await closeRedisClient();
+      process.exit(0);
+    });
+  }
+
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+  process.on("SIGINT", () => shutdown("SIGINT"));
+}
+
+startServer();


### PR DESCRIPTION
## Summary

Refactors the backend entry point to use the Application Factory Pattern, improving testability and startup control.

## Changes

- Split existing `index.js` into:
  - `app.js` — exports `createApp()` to build the Express application without starting the server
  - `server.js` — handles environment validation, service initialization, and server boot
- Removed automatic server startup on import
- Updated package scripts to use `server.js` as the entry point
- Preserved existing middleware, routes, and shutdown logic

## Motivation

The previous implementation started the server immediately upon import, which caused issues for integration testing frameworks that need to spawn and control server instances.

This refactor:

- Eliminates race conditions during tests
- Enables controlled startup and teardown
- Improves separation of concerns
- Aligns with common Node.js backend architecture patterns

## Testing

- Verified server boots successfully with environment variables configured
- Health endpoint (`/health`) responds as expected
- Swagger docs (`/api-docs`) load correctly
- Graceful shutdown works on SIGINT/SIGTERM

## Notes

No functional changes to API behavior.

close #93 