### PR TITLE
feat: add POST /api/webhooks/test endpoint for merchant webhook testing

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -8,6 +8,7 @@ import { ZodError } from "zod";
 import createPaymentsRouter from "./routes/payments.js";
 import merchantsRouter from "./routes/merchants.js";
 import metricsRouter from "./routes/metrics.js";
+import webhooksRouter from "./routes/webhooks.js";
 
 import { requireApiKeyAuth } from "./lib/auth.js";
 import { isHorizonReachable } from "./lib/stellar.js";
@@ -60,6 +61,7 @@ export async function createApp({ redisClient }) {
 
   app.use(express.json({ limit: "1mb" }));
   app.use(morgan("dev"));
+  
 
   // Health check
   app.get("/health", async (req, res) => {
@@ -106,10 +108,12 @@ export async function createApp({ redisClient }) {
   app.use("/api/payments", requireApiKeyAuth());
   app.use("/api/rotate-key", requireApiKeyAuth());
   app.use("/api/merchant-branding", requireApiKeyAuth());
+  app.use("/api/webhooks", requireApiKeyAuth());
 
   app.use("/api", createPaymentsRouter({ verifyPaymentRateLimit }));
   app.use("/api", merchantsRouter);
   app.use("/api", metricsRouter);
+  app.use("/api", webhooksRouter);
 
   app.use((err, req, res, next) => {
     if (err instanceof ZodError) {

--- a/backend/src/routes/webhooks.js
+++ b/backend/src/routes/webhooks.js
@@ -1,0 +1,89 @@
+import express from "express";
+import { supabase } from "../lib/supabase.js";
+import { sendWebhook } from "../lib/webhooks.js";
+
+const router = express.Router();
+
+/**
+ * @swagger
+ * /api/webhooks/test:
+ *   post:
+ *     summary: Send a test webhook to the merchant's stored webhook URL
+ *     tags: [Webhooks]
+ *     security:
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: Test webhook dispatched
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                 status:
+ *                   type: integer
+ *                 body:
+ *                   type: string
+ *                 signed:
+ *                   type: boolean
+ *       400:
+ *         description: No webhook URL configured
+ *       401:
+ *         description: Missing or invalid API key
+ */
+
+router.post("/webhooks/test", async (req, res, next) => {
+  try {
+    // 1. Fetch the merchant's webhook_url and webhook_secret from DB
+    const { data: merchant, error } = await supabase
+      .from("merchants")
+      .select("webhook_url, webhook_secret")
+      .eq("id", req.merchant.id)
+      .maybeSingle();
+
+    if (error) {
+      error.status = 500;
+      throw error;
+    }
+
+    // 2. Guard: merchant must have a webhook URL saved
+    if (!merchant?.webhook_url) {
+      return res.status(400).json({
+        error: "No webhook URL configured for this merchant.",
+      });
+    }
+
+    // 3. Build a dummy payload mimicking a real payment.confirmed event
+    const dummyPayload = {
+      event: "payment.confirmed",
+      test: true,
+      payment_id: "00000000-0000-0000-0000-000000000000",
+      amount: "1.00",
+      asset: "XLM",
+      asset_issuer: null,
+      recipient: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+      tx_id: "test_tx_abc123",
+    };
+
+    // 4. Send the webhook using the existing sendWebhook utility
+    const result = await sendWebhook(
+      merchant.webhook_url,
+      dummyPayload,
+      merchant.webhook_secret
+    );
+
+    // 5. Return the result
+    res.json({
+      ok: result.ok,
+      status: result.status,
+      body: result.body,
+      signed: result.signed,
+    });
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary

Closes #79

Adds a `POST /api/webhooks/test` endpoint that allows merchants to test their webhook URL integration before receiving actual customer payments.

## What Changed

### New File — `backend/src/routes/webhooks.js`
- Adds `POST /api/webhooks/test` route
- Fetches the authenticated merchant's stored `webhook_url` and `webhook_secret` from the database
- Returns a `400` error if no webhook URL is configured
- Dispatches a dummy `payment.confirmed` event to the merchant's webhook URL using the existing `sendWebhook()` utility
- Returns success or failure status and the response body from the merchant's endpoint

### Modified — `backend/src/app.js`
- Imports the new `webhooksRouter`
- Protects `POST /api/webhooks/test` with `requireApiKeyAuth()` middleware
- Registers the webhooks router under `/api`

## Test Payload Dispatched
```json
{
  "event": "payment.confirmed",
  "test": true,
  "payment_id": "00000000-0000-0000-0000-000000000000",
  "amount": "1.00",
  "asset": "XLM",
  "asset_issuer": null,
  "recipient": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
  "tx_id": "test_tx_abc123"
}
```

## Example Response

**Success:**
```json
{
  "ok": true,
  "status": 200,
  "body": "OK",
  "signed": true
}
```

**No webhook URL configured:**
```json
{
  "error": "No webhook URL configured for this merchant."
}
```

## Notes

- Reuses the existing `sendWebhook()` utility from `lib/webhooks.js` — no duplication of signing or dispatch logic
- The dummy payload includes `"test": true` so merchants can distinguish test events from real ones
- The endpoint is protected by API key auth, consistent with other merchant-facing endpoints
- No database writes are performed — this is a pure dispatch test

close #79 