### PR TITLE
feat: merchant-level allowed_issuers for trusted issuer enforcement

### DIFF
--- a/backend/migrations/20260326000006_add_allowed_issuers.js
+++ b/backend/migrations/20260326000006_add_allowed_issuers.js
@@ -1,0 +1,18 @@
+/**
+ * Migration 006: Add allowed_issuers column to merchants.
+ * Stores an array of trusted Stellar issuer addresses as JSONB:
+ *   ["GA5Z6XZ...", "GBPK2A6..."]
+ * An empty array (or null) means all issuers are accepted.
+ */
+
+export async function up(knex) {
+  await knex.raw(
+    "alter table merchants add column if not exists allowed_issuers jsonb"
+  );
+}
+
+export async function down(knex) {
+  await knex.schema.alterTable("merchants", (t) => {
+    t.dropColumn("allowed_issuers");
+  });
+}

--- a/backend/src/routes/merchants.js
+++ b/backend/src/routes/merchants.js
@@ -430,4 +430,104 @@ router.put("/merchant-limits", async (req, res, next) => {
   }
 });
 
+// Stellar public keys start with 'G' and are 56 characters long.
+const stellarAddressSchema = z
+  .string()
+  .trim()
+  .refine(
+    (v) => v.startsWith("G") && v.length === 56,
+    "Each issuer must be a valid Stellar public key (starts with 'G', 56 characters)"
+  );
+
+const allowedIssuersSchema = z.array(stellarAddressSchema);
+
+/**
+ * @swagger
+ * /api/merchant-issuers:
+ *   get:
+ *     summary: Get the allowed issuers list for the authenticated merchant
+ *     tags: [Merchants]
+ *     security:
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: Current allowed issuers list (empty array means all issuers accepted)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 allowed_issuers:
+ *                   type: array
+ *                   items:
+ *                     type: string
+ */
+router.get("/merchant-issuers", async (req, res, next) => {
+  try {
+    const { data, error } = await supabase
+      .from("merchants")
+      .select("allowed_issuers")
+      .eq("id", req.merchant.id)
+      .maybeSingle();
+
+    if (error) {
+      error.status = 500;
+      throw error;
+    }
+
+    res.json({ allowed_issuers: data?.allowed_issuers ?? [] });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * @swagger
+ * /api/merchant-issuers:
+ *   put:
+ *     summary: Set the allowed issuers list for the authenticated merchant
+ *     tags: [Merchants]
+ *     security:
+ *       - ApiKeyAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [allowed_issuers]
+ *             properties:
+ *               allowed_issuers:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *                 description: Array of trusted Stellar issuer public keys. Send an empty array to allow all issuers.
+ *     responses:
+ *       200:
+ *         description: Updated allowed issuers list
+ *       400:
+ *         description: Validation error
+ */
+router.put("/merchant-issuers", async (req, res, next) => {
+  try {
+    const body = z.object({ allowed_issuers: allowedIssuersSchema }).parse(req.body || {});
+
+    const { data, error } = await supabase
+      .from("merchants")
+      .update({ allowed_issuers: body.allowed_issuers })
+      .eq("id", req.merchant.id)
+      .select("allowed_issuers")
+      .single();
+
+    if (error) {
+      error.status = 500;
+      throw error;
+    }
+
+    res.json({ allowed_issuers: data.allowed_issuers });
+  } catch (err) {
+    next(err);
+  }
+});
+
 export default router;

--- a/backend/src/routes/payments.js
+++ b/backend/src/routes/payments.js
@@ -146,6 +146,17 @@ function createPaymentsRouter({
         }
       }
 
+      // Allowed-issuers check: if the merchant has configured a non-empty
+      // allowlist, only those issuer addresses may be used.
+      const allowedIssuers = req.merchant.allowed_issuers;
+      if (Array.isArray(allowedIssuers) && allowedIssuers.length > 0) {
+        if (!body.asset_issuer || !allowedIssuers.includes(body.asset_issuer)) {
+          return res.status(400).json({
+            error: "asset_issuer is not in the merchant's list of allowed issuers",
+          });
+        }
+      }
+
       const paymentId = randomUUID();
       const now = new Date().toISOString();
       const paymentLinkBase =


### PR DESCRIPTION
## Summary

Closes #157 (on emdevelopa/Stellar_Payment_API)

- Adds `allowed_issuers` JSONB column to the `merchants` table (migration 006)
- New `GET /api/merchant-issuers` endpoint returns the merchant's current allowlist
- New `PUT /api/merchant-issuers` endpoint lets merchants set their trusted issuer addresses (validated as proper Stellar public keys)
- `createSession` now rejects payment creation with a `400` if the requested `asset_issuer` is not in the merchant's allowlist
- Default behaviour is unchanged: a `null` or empty allowlist means all issuers are accepted

## Test plan

- [ ] Run migration 006 and confirm `allowed_issuers` column is added
- [ ] `PUT /api/merchant-issuers` with a valid Stellar key array — confirm 200 and persisted value
- [ ] `PUT /api/merchant-issuers` with an invalid key — confirm 400 validation error
- [ ] `GET /api/merchant-issuers` — confirm returns the saved list
- [ ] Create a payment with `asset_issuer` in the allowlist — confirm 201
- [ ] Create a payment with `asset_issuer` NOT in the allowlist — confirm 400 with `"asset_issuer is not in the merchant's list of allowed issuers"`
- [ ] Create a payment when allowlist is empty — confirm 201 (no restriction)