### PR TITLE
feat: implement unified authenticated dashboard hub

### DIFF
--- a/backend/src/routes/payments.js
+++ b/backend/src/routes/payments.js
@@ -588,10 +588,18 @@ function createPaymentsRouter({
         }
       }
 
+      const confirmedCount = payments.filter((p) => p.status === "confirmed").length;
+      const successRate =
+        payments.length > 0
+          ? Number(((confirmedCount / payments.length) * 100).toFixed(1))
+          : 0;
+
       res.json({
         data,
         total_volume: Number(totalVolume.toFixed(2)),
         total_payments: payments.length,
+        confirmed_count: confirmedCount,
+        success_rate: successRate,
       });
     } catch (err) {
       next(err);

--- a/frontend/src/app/(authenticated)/dashboard/page.tsx
+++ b/frontend/src/app/(authenticated)/dashboard/page.tsx
@@ -60,6 +60,27 @@ export default function DashboardPage() {
                 </svg>
                 Withdraw Funds (SEP-24)
               </button>
+              <Link
+                href="/settings"
+                className="flex items-center gap-3 rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-medium text-slate-300 transition-all hover:bg-white/10 hover:text-white"
+              >
+                <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
+                Settings
+              </Link>
+              <a
+                href="/api-docs"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-3 rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-medium text-slate-300 transition-all hover:bg-white/10 hover:text-white"
+              >
+                <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+                </svg>
+                View Docs
+              </a>
             </div>
           </section>
 

--- a/frontend/src/components/PaymentMetrics.tsx
+++ b/frontend/src/components/PaymentMetrics.tsx
@@ -42,6 +42,8 @@ interface MetricsResponse {
   data: MetricData[];
   total_volume: number;
   total_payments: number;
+  confirmed_count: number;
+  success_rate: number;
 }
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -174,7 +176,7 @@ export default function PaymentMetrics() {
     <div className="flex flex-col gap-6">
       {/* Summary cards */}
       {summary && (
-        <div className="grid gap-4 sm:grid-cols-2">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
           <div className="rounded-xl border border-white/10 bg-white/5 p-4 backdrop-blur">
             <p className="font-mono text-xs uppercase tracking-wider text-slate-400">
               7-Day Volume
@@ -198,6 +200,32 @@ export default function PaymentMetrics() {
               <p className="text-sm text-slate-400">
                 {summary.total_payments === 1 ? "payment" : "payments"}
               </p>
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-white/10 bg-white/5 p-4 backdrop-blur">
+            <p className="font-mono text-xs uppercase tracking-wider text-slate-400">
+              Confirmed
+            </p>
+            <div className="mt-2 flex items-baseline gap-2">
+              <p className="text-3xl font-bold text-green-400">
+                {summary.confirmed_count}
+              </p>
+              <p className="text-sm text-slate-400">
+                {summary.confirmed_count === 1 ? "intent" : "intents"}
+              </p>
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-white/10 bg-white/5 p-4 backdrop-blur">
+            <p className="font-mono text-xs uppercase tracking-wider text-slate-400">
+              Success Rate
+            </p>
+            <div className="mt-2 flex items-baseline gap-2">
+              <p className="text-3xl font-bold text-green-400">
+                {summary.success_rate}
+              </p>
+              <p className="text-sm text-slate-400">%</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Extend `/api/metrics/7day` to return `confirmed_count` and `success_rate` (computed from existing payment data, no extra DB query)
- Add **Confirmed Intents** and **Success Rate** stat cards to `PaymentMetrics` — summary grid expands from 2 to 4 cards
- Add **Settings** and **View Docs** quick action buttons to the dashboard sidebar

Closes https://github.com/emdevelopa/Stellar_Payment_API/issues/232

## Test plan
- [ ] Log in as a merchant and navigate to `/dashboard`
- [ ] Confirm 4 stat cards render: 7-Day Volume, Total Payments, Confirmed, Success Rate
- [ ] Verify Confirmed count and Success Rate reflect actual payment statuses
- [ ] Click **Settings** and land on `/settings`
- [ ] Click **View Docs** and open `/api-docs` in a new tab
- [ ] Verify loading skeleton shows while metrics fetch

Generated with [Claude Code](https://claude.com/claude-code)
