### PR TITLE
fix: improve backend setup docs and SEP-10 env handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ This project aims to feel like Stripe/PayPal, but built on Stellar. Merchants cr
 - Stellar: `stellar-sdk` + Horizon API
 - Frontend: Next.js + Tailwind (starter shell in `frontend/`)
 
+## Prerequisites
+
+- Node.js 20+
+- Redis (required for backend rate limiting)
+- Supabase project (URL, service role key, and Postgres connection string)
+
 ## Quick Start (Backend)
 
 1. Install dependencies:
@@ -30,6 +36,19 @@ npm install
 2. Configure environment:
 ```bash
 cp .env.example .env
+```
+
+If you skip this, backend startup validation fails and prints missing required keys.
+
+Optional: bring up Redis quickly with Docker:
+```bash
+docker run --name stellar-redis -p 6379:6379 redis:7-alpine
+```
+
+Or install Redis locally (example with Homebrew):
+```bash
+brew install redis
+brew services start redis
 ```
 
 3. Fill out `backend/.env`:
@@ -53,6 +72,11 @@ CREATE_PAYMENT_RATE_LIMIT_WINDOW_MS=60000
 5. Run the API:
 ```bash
 npm run dev
+```
+
+Or start Redis + API together from the backend folder:
+```bash
+docker compose up
 ```
 
 API will be available at `http://localhost:4000`.

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  redis:
+    image: redis:7-alpine
+    container_name: stellar-payment-redis
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  api:
+    image: node:20-alpine
+    container_name: stellar-payment-api
+    working_dir: /app
+    volumes:
+      - .:/app
+    command: sh -c "npm install && npm run dev"
+    env_file:
+      - .env
+    ports:
+      - "4000:4000"
+    depends_on:
+      redis:
+        condition: service_healthy

--- a/backend/src/lib/env-validation.js
+++ b/backend/src/lib/env-validation.js
@@ -14,7 +14,10 @@ function validateEnvironmentVariables() {
     missing.forEach(key => {
       console.error(`   - ${key}`);
     });
-    console.error('\nPlease set these variables in your .env file or environment.');
+    console.error('\nCreate your local env file before starting the API:');
+    console.error('   cp .env.example .env');
+    console.error('Then fill in the required values in backend/.env.');
+    console.error('Setup guide: README.md#quick-start-backend');
     process.exit(1);
   }
 

--- a/backend/src/lib/sep10-auth.js
+++ b/backend/src/lib/sep10-auth.js
@@ -12,10 +12,9 @@ const NETWORK_PASSPHRASE =
     ? StellarSdk.Networks.PUBLIC
     : StellarSdk.Networks.TESTNET;
 
-const SERVER_SIGNING_KEY = process.env.SEP10_SERVER_SIGNING_KEY;
 const CHALLENGE_EXPIRES_IN = 300; // 5 minutes
 
-if (!SERVER_SIGNING_KEY) {
+if (!process.env.SEP10_SERVER_SIGNING_KEY) {
   console.warn("⚠️  SEP10_SERVER_SIGNING_KEY not set — SEP-0010 auth disabled");
 }
 
@@ -26,11 +25,13 @@ if (!SERVER_SIGNING_KEY) {
  * @returns {string} Base64-encoded challenge transaction XDR
  */
 export function generateChallenge(clientAccountId, homeDomain = "localhost") {
-  if (!SERVER_SIGNING_KEY) {
+  const serverSigningKey = process.env.SEP10_SERVER_SIGNING_KEY;
+
+  if (!serverSigningKey) {
     throw new Error("SEP-0010 server signing key not configured");
   }
 
-  const serverKeypair = StellarSdk.Keypair.fromSecret(SERVER_SIGNING_KEY);
+  const serverKeypair = StellarSdk.Keypair.fromSecret(serverSigningKey);
   const nonce = randomBytes(32).toString("base64");
 
   const now = Math.floor(Date.now() / 1000);
@@ -68,12 +69,14 @@ export function generateChallenge(clientAccountId, homeDomain = "localhost") {
  * @returns {{ valid: boolean, error?: string }}
  */
 export function verifyChallenge(challengeXdr, clientAccountId) {
-  if (!SERVER_SIGNING_KEY) {
+  const serverSigningKey = process.env.SEP10_SERVER_SIGNING_KEY;
+
+  if (!serverSigningKey) {
     return { valid: false, error: "SEP-0010 not configured" };
   }
 
   try {
-    const serverKeypair = StellarSdk.Keypair.fromSecret(SERVER_SIGNING_KEY);
+    const serverKeypair = StellarSdk.Keypair.fromSecret(serverSigningKey);
     const transaction = new StellarSdk.TransactionBuilder.fromXDR(
       challengeXdr,
       NETWORK_PASSPHRASE,


### PR DESCRIPTION
## Summary
- improve backend startup env validation guidance with explicit `.env` setup instructions and quick-start documentation updates
- lazy-load `SEP10_SERVER_SIGNING_KEY` at call time in SEP-0010 auth helpers to avoid module-load env caching issues
- add `backend/docker-compose.yml` for local Redis + API startup, and document Redis prerequisites

## Notes
- frontend lint passes locally
- backend tests currently have one unrelated pre-existing failure in `src/lib/stellar.test.js` (memo-type assertion), not introduced by this branch

Closes #268
Closes #269
Closes #270
Closes #271