### PR TITLE
fix: improved health check resilience for Horizon

### DIFF
--- a/backend/src/lib/stellar.js
+++ b/backend/src/lib/stellar.js
@@ -9,13 +9,31 @@ const HORIZON_URL =
     : "https://horizon-testnet.stellar.org");
 
 const server = new StellarSdk.Horizon.Server(HORIZON_URL);
+const HORIZON_HEALTH_TIMEOUT_MS = 2_000;
 
 export async function isHorizonReachable() {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    HORIZON_HEALTH_TIMEOUT_MS,
+  );
+
   try {
-    await server.ledgers().order("desc").limit(1).call();
-    return true;
+    const response = await fetch(HORIZON_URL, {
+      method: "GET",
+      signal: controller.signal,
+      headers: {
+        Accept: "application/json",
+      },
+    });
+
+    // Treat rate limiting as reachable so transient Horizon throttling
+    // doesn't fail the entire API health check.
+    return response.ok || response.status === 429;
   } catch {
     return false;
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 


### PR DESCRIPTION
close #244 
Description

  ## Summary
  This change makes the `/health` endpoint more resilient by
  replacing the current Horizon reachability check with a lightweight
  root request and a strict 2-second timeout.

  ## Problem
  The previous health check used a full Horizon ledger call, which
  was heavier than necessary and could fail under mild latency or
  temporary rate limiting. That caused `/health` to return `503` even
  when Horizon was still reachable.

  ## Changes
  - Updated `isHorizonReachable` in `backend/src/lib/stellar.js`
  - Replaced the full ledger query with a lightweight `fetch` to the
  Horizon root URL
  - Added a strict 2-second timeout using `AbortController`
  - Treated HTTP `429` responses as reachable so temporary Horizon
  throttling does not mark the API unhealthy

  ## Result
  The health endpoint is now less fragile and less likely to report
  Horizon as unavailable during short network slowdowns or rate-limit
  events.

  ## Verification
  - Confirmed the change is isolated to the Horizon reachability
  check
  - Local automated test execution was not available in this checkout
  because `vitest` is not installed (`npm test` fails with `vitest:
  not found`)
