### PR TITLE
Bugfix/payment matching

### DIFF
--- a/backend/src/lib/stellar.js
+++ b/backend/src/lib/stellar.js
@@ -69,8 +69,15 @@ function paymentMatchesAsset(payment, asset) {
     return payment.asset_type === "native";
   }
 
+  const expectedCode =
+    typeof asset.getCode === "function" ? asset.getCode() : asset.code;
+  const expectedIssuer =
+    typeof asset.getIssuer === "function" ? asset.getIssuer() : asset.issuer;
+
   return (
-    payment.asset_code === asset.code && payment.asset_issuer === asset.issuer
+    String(payment.asset_code || "").toUpperCase() ===
+      String(expectedCode || "").toUpperCase() &&
+    String(payment.asset_issuer || "") === String(expectedIssuer || "")
   );
 }
 
@@ -126,9 +133,12 @@ function handleHorizonError(err, context = "") {
 function memoMatches(tx, expectedMemo, expectedMemoType) {
   const txMemoType = (tx.memo_type || "none").toLowerCase();
   const wantType = (expectedMemoType || "text").toLowerCase();
+  const normalizedTxMemo = tx.memo == null ? "" : String(tx.memo);
+  const normalizedExpectedMemo =
+    expectedMemo == null ? "" : String(expectedMemo);
 
   if (txMemoType !== wantType) return false;
-  return String(tx.memo) === String(expectedMemo);
+  return normalizedTxMemo === normalizedExpectedMemo;
 }
 
 /**


### PR DESCRIPTION
close #243 

## Summary
  This PR fixes the Stellar payment matching logic in `backend/src/
  lib/stellar.js` so valid payments are no longer rejected during
  verification.

  ## Problem
  `findMatchingPayment` was returning `null` for valid transactions
  in cases that should have matched. The failures were caused by two
  issues:
  - non-native asset matching was too rigid about how asset code and
  issuer were read
  - memo comparison did not normalize optional values consistently
  when `null` or `undefined` were involved

  These issues broke the payment confirmation flow and caused the
  failing assertions in `backend/src/lib/stellar.test.js`.

  ## Changes
  - updated non-native asset matching to support both SDK getter-
  based assets and plain asset fields
  - normalized asset code comparison to avoid false negatives caused
  by casing or shape differences
  - normalized memo values before comparison so optional memo fields
  behave correctly when values are `null` or `undefined`
  - kept existing payment filtering behavior intact for destination
  checks, amount checks, and memo type validation

  ## Result
  Valid XLM and issued-asset payments now match correctly, memo
  validation behaves consistently for optional fields, and the
  payment verification path returns the expected transaction object
  instead of `null`.

  ## Verification
  - `npm test -- src/lib/stellar.test.js`
  - Result: `23 passed, 0 failed`

  ## Notes
  A full `npm test` run still shows unrelated pre-existing failures
  in:
  - `src/lib/sep10-auth.test.js`
  - `src/lib/auth.test.js`

  Those failures are outside the scope of this PR.