### PR TITLE
ux: improve key generation onboarding for new merchants

### DIFF
--- a/backend/src/lib/auth.js
+++ b/backend/src/lib/auth.js
@@ -75,3 +75,38 @@ export function createApiKeyAuth({
 export function requireApiKeyAuth(options) {
   return createApiKeyAuth(options);
 }
+
+export function requireSessionAuth() {
+  return async function (req, res, next) {
+    try {
+      const authHeader = req.get("Authorization");
+      if (!authHeader || !authHeader.startsWith("Bearer ")) {
+        return res.status(401).json({ error: "Missing or invalid Authorization header" });
+      }
+
+      const token = authHeader.split(" ")[1];
+      const { verifySessionToken } = await import("./sep10-auth.js");
+      const { valid, payload, error: verifyError } = verifySessionToken(token);
+
+      if (!valid) {
+        return res.status(401).json({ error: verifyError || "Invalid session token" });
+      }
+
+      const client = (await import("./supabase.js")).supabase;
+      const { data: merchant, error } = await client
+        .from("merchants")
+        .select("id, email, business_name, notification_email, api_key")
+        .eq("id", payload.merchant_id)
+        .maybeSingle();
+
+      if (error || !merchant) {
+        return res.status(401).json({ error: "Merchant not found" });
+      }
+
+      req.merchant = merchant;
+      next();
+    } catch (err) {
+      next(err);
+    }
+  };
+}

--- a/backend/src/routes/merchants.js
+++ b/backend/src/routes/merchants.js
@@ -1,7 +1,7 @@
 import express from "express";
 import { randomBytes } from "crypto";
 import { supabase } from "../lib/supabase.js";
-import { requireApiKeyAuth } from "../lib/auth.js";
+import { requireApiKeyAuth, requireSessionAuth } from "../lib/auth.js";
 import { getMerchantApiUsage } from "../lib/api-usage.js";
 import {
   registerMerchantZodSchema,
@@ -509,6 +509,45 @@ router.post("/regenerate-webhook-secret", async (req, res, next) => {
     }
 
     res.json({ webhook_secret: newSecret });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * @swagger
+ * /api/merchants/generate-api-key:
+ *   post:
+ *     summary: Generate an API key using session authentication
+ *     tags: [Merchants]
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: New API key issued
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 api_key:
+ *                   type: string
+ */
+router.post("/merchants/generate-api-key", requireSessionAuth(), async (req, res, next) => {
+  try {
+    const newApiKey = `sk_${randomBytes(24).toString("hex")}`;
+
+    const { error } = await supabase
+      .from("merchants")
+      .update({ api_key: newApiKey })
+      .eq("id", req.merchant.id);
+
+    if (error) {
+      error.status = 500;
+      throw error;
+    }
+
+    res.json({ api_key: newApiKey });
   } catch (err) {
     next(err);
   }

--- a/frontend/src/app/(authenticated)/dashboard/page.tsx
+++ b/frontend/src/app/(authenticated)/dashboard/page.tsx
@@ -6,13 +6,16 @@ import RecentPayments from "@/components/RecentPayments";
 import WithdrawalModal from "@/components/WithdrawalModal";
 import DashboardSkeleton from "@/components/DashboardSkeleton";
 import Link from "next/link";
-import { useMerchantHydrated, useHydrateMerchantStore } from "@/lib/merchant-store";
+import { useMerchantHydrated, useHydrateMerchantStore, useMerchantApiKey } from "@/lib/merchant-store";
 import { useTranslations } from "next-intl";
+import FirstApiKeyModal from "@/components/FirstApiKeyModal";
 
 export default function DashboardPage() {
   const t = useTranslations("dashboardPage");
   const [isWithdrawOpen, setIsWithdrawOpen] = useState(false);
+  const [isFirstKeyModalOpen, setIsFirstKeyModalOpen] = useState(false);
   const hydrated = useMerchantHydrated();
+  const apiKey = useMerchantApiKey();
   const [loading, setLoading] = useState(true);
 
   useHydrateMerchantStore();
@@ -25,6 +28,17 @@ export default function DashboardPage() {
       return () => clearTimeout(timer);
     }
   }, [hydrated]);
+
+  useEffect(() => {
+    // Show the "First Key" onboarding modal if the merchant has 0 keys
+    // We wait for the dashboard to finish initial loading first.
+    if (hydrated && !loading && !apiKey) {
+      const timer = setTimeout(() => {
+        setIsFirstKeyModalOpen(true);
+      }, 1500); 
+      return () => clearTimeout(timer);
+    }
+  }, [hydrated, loading, apiKey]);
 
   if (!hydrated || loading) {
     return <DashboardSkeleton />;
@@ -124,6 +138,11 @@ export default function DashboardPage() {
       <WithdrawalModal 
         isOpen={isWithdrawOpen} 
         onClose={() => setIsWithdrawOpen(false)} 
+      />
+
+      <FirstApiKeyModal 
+        isOpen={isFirstKeyModalOpen} 
+        onClose={() => setIsFirstKeyModalOpen(false)} 
       />
     </div>
   );

--- a/frontend/src/components/FirstApiKeyModal.tsx
+++ b/frontend/src/components/FirstApiKeyModal.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import React, { useState } from "react";
+import { Modal } from "./ui/Modal";
+import CopyButton from "./CopyButton";
+import { generateFirstApiKey } from "@/lib/auth";
+import { useSetMerchantApiKey } from "@/lib/merchant-store";
+import toast from "react-hot-toast";
+
+interface FirstApiKeyModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function FirstApiKeyModal({ isOpen, onClose }: FirstApiKeyModalProps) {
+  const [apiKey, setApiKey] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const setStoreApiKey = useSetMerchantApiKey();
+
+  const handleGenerate = async () => {
+    setLoading(true);
+    try {
+      const newKey = await generateFirstApiKey();
+      setApiKey(newKey);
+      setStoreApiKey(newKey);
+      toast.success("API Key generated successfully!");
+    } catch (err: any) {
+      const message = err instanceof Error ? err.message : "Failed to generate API Key";
+      toast.error(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Welcome to Vaultix">
+      <div className="flex flex-col gap-6">
+        {!apiKey ? (
+          <>
+            <div className="flex flex-col gap-2">
+              <h3 className="text-xl font-bold text-white">Generate your first API key</h3>
+              <p className="text-slate-400 text-sm">
+                To start accepting payments, you'll need an API key to authenticate your server-side requests.
+              </p>
+            </div>
+            
+            <button
+              onClick={handleGenerate}
+              disabled={loading}
+              className="w-full rounded-xl bg-mint py-3 font-bold text-black transition-all hover:bg-glow disabled:opacity-50"
+            >
+              {loading ? "Generating..." : "Generate API Key"}
+            </button>
+          </>
+        ) : (
+          <>
+            <div className="flex flex-col gap-2">
+              <h3 className="text-xl font-bold text-mint">Your API Key is ready!</h3>
+              <p className="text-slate-400 text-sm">
+                Copy this key and save it somewhere secure. You won't be able to see it again after closing this window.
+              </p>
+            </div>
+
+            <div className="flex items-center gap-3 rounded-xl border border-white/10 bg-black/40 px-4 py-3">
+              <code className="flex-1 truncate text-sm text-mint">{apiKey}</code>
+              <CopyButton text={apiKey} />
+            </div>
+
+            <div className="flex flex-col gap-3 pt-2">
+              <a
+                href="/api-docs"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-center gap-2 rounded-xl border border-white/10 bg-white/5 py-3 text-sm font-medium text-white transition-all hover:bg-white/10"
+              >
+                View API Documentation
+                <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                </svg>
+              </a>
+              <button
+                onClick={onClose}
+                className="w-full text-center text-sm text-slate-500 hover:text-white transition-colors"
+              >
+                Done
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -128,3 +128,25 @@ export async function registerMerchant(
 export function logout(): void {
   clearToken();
 }
+
+export async function generateFirstApiKey(): Promise<string> {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000";
+  const token = getToken();
+
+  if (!token) throw new Error("No session token found");
+
+  const res = await fetch(`${apiUrl}/api/merchants/generate-api-key`, {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${token}`
+    },
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.error ?? "Failed to generate API key");
+  }
+
+  const { api_key } = await res.json();
+  return api_key;
+}


### PR DESCRIPTION
closes #235

Backend Auth Upgrade: Implemented 

requireSessionAuth
 middleware in 

backend/src/lib/auth.js
 to support session-based authentication for sensitive merchant operations.
New API Endpoint: Added POST /api/merchants/generate-api-key in 

backend/src/routes/merchants.js
. This allows merchants who haven't yet received an API key (or lost their initial one) to generate one using their authenticated session token.
Frontend Integration:
Added a 

generateFirstApiKey
 helper in 

frontend/src/lib/auth.ts
.
Created a new 

FirstApiKeyModal.tsx
 component to guide users through the generation process.
Integrated the modal into the main DashboardPage.tsx with a refined 1.5s delay for a smoother user experience.
