### PR TITLE
feat: integrate optional recaptcha bot protection

### DIFF
--- a/backend/src/lib/recaptcha.js
+++ b/backend/src/lib/recaptcha.js
@@ -1,0 +1,101 @@
+/**
+ * Optional Google reCAPTCHA v2/v3 verification middleware.
+ *
+ * When the environment variable RECAPTCHA_SECRET_KEY is set the middleware
+ * verifies the `g-recaptcha-response` field in the request body against
+ * Google's siteverify API.  When the variable is absent the middleware is a
+ * transparent no-op, so deployments that haven't opted into reCAPTCHA are
+ * unaffected.
+ */
+
+const GOOGLE_VERIFY_URL = "https://www.google.com/recaptcha/api/siteverify";
+
+/**
+ * Calls the Google siteverify endpoint and returns the parsed JSON response.
+ *
+ * @param {string} secret   The server-side reCAPTCHA secret key.
+ * @param {string} token    The `g-recaptcha-response` token from the client.
+ * @param {string} [remoteip] Optional request IP for extra validation.
+ * @returns {Promise<{success: boolean, [key: string]: unknown}>}
+ */
+async function verifyCaptchaToken(secret, token, remoteip) {
+  const params = new URLSearchParams({ secret, response: token });
+  if (remoteip) params.append("remoteip", remoteip);
+
+  const res = await fetch(GOOGLE_VERIFY_URL, {
+    method: "POST",
+    body: params,
+  });
+
+  return res.json();
+}
+
+/**
+ * Express middleware factory.
+ *
+ * Usage:
+ *   import { recaptchaMiddleware } from "../lib/recaptcha.js";
+ *   router.post("/create-payment", recaptchaMiddleware(), ...);
+ *
+ * Configuration (env vars):
+ *   RECAPTCHA_SECRET_KEY  – server-side secret.  Feature disabled when absent.
+ *   RECAPTCHA_MIN_SCORE   – minimum v3 score (0.0 – 1.0), default 0.5.
+ *                           Ignored for v2 tokens.
+ */
+export function recaptchaMiddleware() {
+  const secret = process.env.RECAPTCHA_SECRET_KEY;
+
+  // No secret configured → middleware is a transparent pass-through.
+  if (!secret) {
+    return (_req, _res, next) => next();
+  }
+
+  const minScore = parseFloat(process.env.RECAPTCHA_MIN_SCORE ?? "0.5");
+
+  return async (req, res, next) => {
+    const token = req.body?.["g-recaptcha-response"];
+
+    if (!token) {
+      return res.status(400).json({
+        error: "reCAPTCHA token required",
+        code: "RECAPTCHA_MISSING",
+      });
+    }
+
+    try {
+      const remoteip =
+        req.ip ||
+        req.headers["x-forwarded-for"]?.split(",")[0]?.trim() ||
+        undefined;
+
+      const result = await verifyCaptchaToken(secret, token, remoteip);
+
+      if (!result.success) {
+        const codes = result["error-codes"] ?? [];
+        return res.status(403).json({
+          error: "reCAPTCHA verification failed",
+          code: "RECAPTCHA_FAILED",
+          details: codes,
+        });
+      }
+
+      // reCAPTCHA v3 returns a score; v2 does not.
+      if (typeof result.score === "number" && result.score < minScore) {
+        return res.status(403).json({
+          error: "reCAPTCHA score too low",
+          code: "RECAPTCHA_SCORE_LOW",
+          score: result.score,
+        });
+      }
+
+      // Attach the verification result for downstream handlers.
+      req.recaptcha = result;
+      return next();
+    } catch (err) {
+      // Network or parse failure: fail open with a warning so a Google
+      // outage never blocks legitimate payments.
+      console.warn("reCAPTCHA verification error (failing open):", err.message);
+      return next();
+    }
+  };
+}

--- a/backend/src/routes/payments.js
+++ b/backend/src/routes/payments.js
@@ -12,6 +12,7 @@ import {
 } from "../lib/request-schemas.js";
 import { validateRequest } from "../lib/validation.js";
 import { createCreatePaymentRateLimit } from "../lib/create-payment-rate-limit.js";
+import { recaptchaMiddleware } from "../lib/recaptcha.js";
 import { sendWebhook } from "../lib/webhooks.js";
 import { sendReceiptEmail } from "../lib/email.js";
 import { renderReceiptEmail } from "../lib/email-templates.js";
@@ -260,7 +261,7 @@ function createPaymentsRouter({
     }
   }
 
-  router.post("/create-payment", createPaymentRateLimit, validateRequest({ body: paymentSessionZodSchema }), sanitizeMetadataMiddleware, createSession);
+  router.post("/create-payment", createPaymentRateLimit, recaptchaMiddleware(), validateRequest({ body: paymentSessionZodSchema }), sanitizeMetadataMiddleware, createSession);
   router.post("/sessions", createPaymentRateLimit, validateRequest({ body: paymentSessionZodSchema }), sanitizeMetadataMiddleware, createSession);
 
   /**

--- a/backend/tests/integration/recaptcha.test.js
+++ b/backend/tests/integration/recaptcha.test.js
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import express from "express";
+import request from "supertest";
+import { recaptchaMiddleware } from "../../src/lib/recaptcha.js";
+
+function makeApp(envSecret) {
+  const app = express();
+  app.use(express.json());
+
+  // Temporarily set the env var for this app instance
+  if (envSecret) process.env.RECAPTCHA_SECRET_KEY = envSecret;
+  else delete process.env.RECAPTCHA_SECRET_KEY;
+
+  app.post("/test", recaptchaMiddleware(), (req, res) => {
+    res.json({ ok: true, recaptcha: req.recaptcha ?? null });
+  });
+
+  return app;
+}
+
+describe("recaptchaMiddleware", () => {
+  afterEach(() => {
+    delete process.env.RECAPTCHA_SECRET_KEY;
+    vi.restoreAllMocks();
+  });
+
+  it("is a no-op when RECAPTCHA_SECRET_KEY is not set", async () => {
+    const app = makeApp(undefined);
+    const res = await request(app).post("/test").send({ amount: 10 });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it("returns 400 when token is missing and secret is configured", async () => {
+    const app = makeApp("test-secret");
+    const res = await request(app).post("/test").send({ amount: 10 });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("RECAPTCHA_MISSING");
+  });
+
+  it("returns 403 when Google returns success=false", async () => {
+    vi.stubGlobal("fetch", async () => ({
+      json: async () => ({ success: false, "error-codes": ["invalid-input-response"] }),
+    }));
+
+    const app = makeApp("test-secret");
+    const res = await request(app)
+      .post("/test")
+      .send({ "g-recaptcha-response": "bad-token" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe("RECAPTCHA_FAILED");
+  });
+
+  it("returns 403 when v3 score is below minimum", async () => {
+    vi.stubGlobal("fetch", async () => ({
+      json: async () => ({ success: true, score: 0.1 }),
+    }));
+
+    const app = makeApp("test-secret");
+    const res = await request(app)
+      .post("/test")
+      .send({ "g-recaptcha-response": "low-score-token" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe("RECAPTCHA_SCORE_LOW");
+  });
+
+  it("passes through and attaches result when verification succeeds", async () => {
+    vi.stubGlobal("fetch", async () => ({
+      json: async () => ({ success: true, score: 0.9 }),
+    }));
+
+    const app = makeApp("test-secret");
+    const res = await request(app)
+      .post("/test")
+      .send({ "g-recaptcha-response": "good-token" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.recaptcha.success).toBe(true);
+  });
+
+  it("fails open (next()) when Google call throws a network error", async () => {
+    vi.stubGlobal("fetch", async () => { throw new Error("network error"); });
+
+    const app = makeApp("test-secret");
+    const res = await request(app)
+      .post("/test")
+      .send({ "g-recaptcha-response": "any-token" });
+
+    // Should not block the request on Google outage
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #432

## Summary
- Add `src/lib/recaptcha.js` middleware factory; transparent no-op when `RECAPTCHA_SECRET_KEY` is absent
- Verifies `g-recaptcha-response` via Google siteverify; returns 400 if missing, 403 if invalid/score too low
- v3 score threshold configurable via `RECAPTCHA_MIN_SCORE` (default 0.5)
- Fails open on Google network errors so outages never block payments
- Wire `recaptchaMiddleware()` into `POST /create-payment` between rate-limiter and schema validation

## Test plan
- [ ] 6 tests pass: no-op, missing token, failed verification, low score, success, network fail-open