### PR TITLE
feat: webhook event subscriptions per merchant (#414)

### DIFF
--- a/backend/src/lib/request-schemas.js
+++ b/backend/src/lib/request-schemas.js
@@ -216,6 +216,12 @@ export const v2PaymentSessionSchema = paymentSessionZodSchema;
 
 const SAFE_HEADER_NAME_RE = /^[a-zA-Z0-9\-_]+$/;
 
+export const VALID_WEBHOOK_EVENTS = [
+  "payment.confirmed",
+  "payment.failed",
+  "payment.expired",
+];
+
 export const webhookSettingsSchema = z.object({
   webhook_url: z.preprocess(
     (value) => {
@@ -237,6 +243,15 @@ export const webhookSettingsSchema = z.object({
     .refine(
       (obj) => Object.keys(obj).every((k) => SAFE_HEADER_NAME_RE.test(k)),
       "Header names must contain only alphanumeric characters, hyphens, or underscores",
+    )
+    .optional()
+    .nullable(),
+  subscribed_events: z
+    .array(
+      z.string().refine(
+        (e) => VALID_WEBHOOK_EVENTS.includes(e),
+        (e) => ({ message: `"${e}" is not a valid event type. Valid values: ${VALID_WEBHOOK_EVENTS.join(", ")}` }),
+      ),
     )
     .optional()
     .nullable(),
@@ -273,7 +288,11 @@ export const authChallengeSchema = z.object({
       invalid_type_error: "Account must be a string",
     })
     .trim()
-    .min(1, "destination_address is required"),
+    .min(1, "destination_address is required")
+    .refine(
+      (val) => val.startsWith("G") && val.length === 56,
+      "Invalid Stellar address",
+    ),
   description: paymentBaseSchema.shape.description,
   memo: paymentBaseSchema.shape.memo,
   memo_type: paymentBaseSchema.shape.memo_type,
@@ -283,10 +302,6 @@ export const authChallengeSchema = z.object({
   }, "callback_url must be a valid URL"),
   client_id: paymentBaseSchema.shape.client_id,
   metadata: z.unknown().optional(),
-    .refine(
-      (val) => val.startsWith("G") && val.length === 56,
-      "Invalid Stellar address",
-    ),
 });
 
 export const authVerifySchema = z.object({

--- a/backend/src/lib/webhook-subscriptions.test.js
+++ b/backend/src/lib/webhook-subscriptions.test.js
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("./supabase.js", () => ({
+  supabase: { from: vi.fn() },
+}));
+vi.mock("dotenv/config", () => ({}));
+
+import { isEventSubscribed } from "./webhooks.js";
+import { webhookSettingsSchema, VALID_WEBHOOK_EVENTS } from "./request-schemas.js";
+
+// ── isEventSubscribed ─────────────────────────────────────────────────────────
+
+describe("isEventSubscribed", () => {
+  it("returns true when subscribed_events is null (receive all)", () => {
+    expect(isEventSubscribed({ subscribed_events: null }, "payment.confirmed")).toBe(true);
+  });
+
+  it("returns true when subscribed_events is undefined (receive all)", () => {
+    expect(isEventSubscribed({}, "payment.confirmed")).toBe(true);
+  });
+
+  it("returns true when subscribed_events is an empty array (receive all)", () => {
+    expect(isEventSubscribed({ subscribed_events: [] }, "payment.confirmed")).toBe(true);
+  });
+
+  it("returns true when the event is in the subscribed list", () => {
+    expect(
+      isEventSubscribed(
+        { subscribed_events: ["payment.confirmed", "payment.failed"] },
+        "payment.confirmed",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when the event is NOT in the subscribed list", () => {
+    expect(
+      isEventSubscribed(
+        { subscribed_events: ["payment.failed"] },
+        "payment.confirmed",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for an unrelated event type when list is restricted", () => {
+    expect(
+      isEventSubscribed(
+        { subscribed_events: ["payment.confirmed"] },
+        "payment.expired",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns true when merchant is null (defensive)", () => {
+    expect(isEventSubscribed(null, "payment.confirmed")).toBe(true);
+  });
+
+  it("returns true when merchant is undefined (defensive)", () => {
+    expect(isEventSubscribed(undefined, "payment.confirmed")).toBe(true);
+  });
+
+  it("handles a single-event subscription list correctly", () => {
+    const merchant = { subscribed_events: ["payment.expired"] };
+    expect(isEventSubscribed(merchant, "payment.expired")).toBe(true);
+    expect(isEventSubscribed(merchant, "payment.confirmed")).toBe(false);
+    expect(isEventSubscribed(merchant, "payment.failed")).toBe(false);
+  });
+});
+
+// ── webhookSettingsSchema — subscribed_events field ───────────────────────────
+
+describe("webhookSettingsSchema — subscribed_events validation", () => {
+  it("accepts a valid list of event types", () => {
+    const result = webhookSettingsSchema.safeParse({
+      subscribed_events: ["payment.confirmed", "payment.failed"],
+    });
+    expect(result.success).toBe(true);
+    expect(result.data.subscribed_events).toEqual(["payment.confirmed", "payment.failed"]);
+  });
+
+  it("accepts null to clear all subscriptions", () => {
+    const result = webhookSettingsSchema.safeParse({ subscribed_events: null });
+    expect(result.success).toBe(true);
+    expect(result.data.subscribed_events).toBeNull();
+  });
+
+  it("accepts an empty array", () => {
+    const result = webhookSettingsSchema.safeParse({ subscribed_events: [] });
+    expect(result.success).toBe(true);
+    expect(result.data.subscribed_events).toEqual([]);
+  });
+
+  it("accepts when subscribed_events is omitted", () => {
+    const result = webhookSettingsSchema.safeParse({});
+    expect(result.success).toBe(true);
+    expect(result.data.subscribed_events).toBeUndefined();
+  });
+
+  it("rejects an unknown event type", () => {
+    const result = webhookSettingsSchema.safeParse({
+      subscribed_events: ["payment.unknown"],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a mixed list with one invalid event", () => {
+    const result = webhookSettingsSchema.safeParse({
+      subscribed_events: ["payment.confirmed", "not.an.event"],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts all VALID_WEBHOOK_EVENTS together", () => {
+    const result = webhookSettingsSchema.safeParse({
+      subscribed_events: VALID_WEBHOOK_EVENTS,
+    });
+    expect(result.success).toBe(true);
+    expect(result.data.subscribed_events).toEqual(VALID_WEBHOOK_EVENTS);
+  });
+
+  it("VALID_WEBHOOK_EVENTS includes payment.confirmed, payment.failed, payment.expired", () => {
+    expect(VALID_WEBHOOK_EVENTS).toContain("payment.confirmed");
+    expect(VALID_WEBHOOK_EVENTS).toContain("payment.failed");
+    expect(VALID_WEBHOOK_EVENTS).toContain("payment.expired");
+  });
+});

--- a/backend/src/lib/webhooks.js
+++ b/backend/src/lib/webhooks.js
@@ -235,6 +235,22 @@ export function sanitizeCustomHeaders(raw) {
 }
 
 /**
+ * Returns true if the merchant has subscribed to the given event type.
+ *
+ * When `subscribed_events` is null, undefined, or an empty array the merchant
+ * receives ALL event types (backward-compatible default).
+ *
+ * @param {object} merchant  - Merchant record (may include subscribed_events).
+ * @param {string} eventType - Event type to check, e.g. "payment.confirmed".
+ * @returns {boolean}
+ */
+export function isEventSubscribed(merchant, eventType) {
+  const list = merchant?.subscribed_events;
+  if (!Array.isArray(list) || list.length === 0) return true;
+  return list.includes(eventType);
+}
+
+/**
  * Sends a signed webhook POST request to `url`.
  *
  * @param {string}  url           Destination URL.

--- a/backend/src/routes/merchants.js
+++ b/backend/src/routes/merchants.js
@@ -11,6 +11,7 @@ import {
   sessionBrandingSchema,
   webhookSettingsSchema,
   testWebhookSchema,
+  VALID_WEBHOOK_EVENTS,
 } from "../lib/request-schemas.js";
 import { merchantService } from "../services/merchantService.js";
 import {
@@ -460,7 +461,7 @@ function createMerchantsRouter({
     try {
       const { data, error } = await supabase
         .from("merchants")
-        .select("webhook_url, webhook_secret, metadata")
+        .select("webhook_url, webhook_secret, subscribed_events, metadata")
         .eq("id", req.merchant.id)
         .single();
 
@@ -479,6 +480,8 @@ function createMerchantsRouter({
       res.json({
         webhook_url: data.webhook_url || "",
         webhook_secret_masked: maskedSecret,
+        subscribed_events: data.subscribed_events ?? null,
+        available_events: VALID_WEBHOOK_EVENTS,
         webhook_domain_verification: readWebhookDomainVerification(
           data.metadata,
           data.webhook_url || "",
@@ -523,6 +526,9 @@ function createMerchantsRouter({
         const updatePayload = { webhook_url: body.webhook_url || null };
         if ("custom_headers" in body) {
           updatePayload.webhook_custom_headers = body.custom_headers ?? null;
+        }
+        if ("subscribed_events" in body) {
+          updatePayload.subscribed_events = body.subscribed_events ?? null;
         }
         const { data: existing, error: existingError } = await supabase
           .from("merchants")

--- a/backend/src/routes/payments.js
+++ b/backend/src/routes/payments.js
@@ -13,7 +13,7 @@ import {
 import { validateRequest } from "../lib/validation.js";
 import { createCreatePaymentRateLimit } from "../lib/create-payment-rate-limit.js";
 import { recaptchaMiddleware } from "../lib/recaptcha.js";
-import { sendWebhook } from "../lib/webhooks.js";
+import { sendWebhook, isEventSubscribed } from "../lib/webhooks.js";
 import { sendReceiptEmail } from "../lib/email.js";
 import { renderReceiptEmail } from "../lib/email-templates.js";
 import { resolveBrandingConfig } from "../lib/branding.js";
@@ -423,7 +423,7 @@ function createPaymentsRouter({
         let query = supabase
           .from("payments")
           .select(
-            "id, amount, asset, asset_issuer, recipient, status, tx_id, memo, memo_type, webhook_url, merchants(webhook_secret, webhook_version, webhook_custom_headers, notification_email, email, business_name)"
+            "id, amount, asset, asset_issuer, recipient, status, tx_id, memo, memo_type, webhook_url, merchants(webhook_secret, webhook_version, webhook_custom_headers, notification_email, email, business_name, subscribed_events)"
           );
 
         if (req.merchant?.id) {
@@ -527,13 +527,16 @@ function createPaymentsRouter({
             tx_id: match.transaction_hash,
           }
         );
-        const webhookResult = await sendWebhook(
-          data.webhook_url,
-          webhookPayload,
-          merchantSecret,
-          data.id,
-          data.merchants?.webhook_custom_headers ?? {}
-        );
+        let webhookResult = { ok: true, skipped: true };
+        if (isEventSubscribed(data.merchants, "payment.confirmed")) {
+          webhookResult = await sendWebhook(
+            data.webhook_url,
+            webhookPayload,
+            merchantSecret,
+            data.id,
+            data.merchants?.webhook_custom_headers ?? {}
+          );
+        }
         sendReceiptEmail({
           to: data.merchants?.notification_email,
           businessName: data.merchants?.business_name || "Merchant",


### PR DESCRIPTION
## Summary

- Merchants can now specify which webhook events they want to receive via a `subscribed_events` array (e.g. `["payment.confirmed", "payment.failed"]`)
- When `subscribed_events` is `null`, `undefined`, or an empty array, **all events are sent** (backward-compatible default)
- Adds `isEventSubscribed(merchant, eventType)` helper in `webhooks.js` — used to gate `sendWebhook` before dispatch
- `GET /webhook-settings` now returns `subscribed_events` (current subscription) and `available_events` (full list of valid event types)
- `PUT /webhook-settings` accepts and persists `subscribed_events`; invalid event names are rejected with a descriptive error
- Valid event types: `payment.confirmed`, `payment.failed`, `payment.expired`
- Fixes pre-existing syntax error: orphaned `.refine()` in `authChallengeSchema`

## Test plan

- [x] `webhook-subscriptions.test.js` — 17 tests: `isEventSubscribed` (null/undefined/empty → allow all; subscribed → allow; not subscribed → block; edge cases), `webhookSettingsSchema` validation (valid list, null, empty, omitted, unknown event, mixed invalid, all valid events)
- [x] All tests pass: `npx vitest run src/lib/webhook-subscriptions.test.js`

Closes #414