### PR TITLE
fix: webhook secret rotation — fix schema syntax error blocking tests (#407)

### DIFF
--- a/backend/src/lib/request-schemas.js
+++ b/backend/src/lib/request-schemas.js
@@ -273,7 +273,11 @@ export const authChallengeSchema = z.object({
       invalid_type_error: "Account must be a string",
     })
     .trim()
-    .min(1, "destination_address is required"),
+    .min(1, "destination_address is required")
+    .refine(
+      (val) => val.startsWith("G") && val.length === 56,
+      "Invalid Stellar address",
+    ),
   description: paymentBaseSchema.shape.description,
   memo: paymentBaseSchema.shape.memo,
   memo_type: paymentBaseSchema.shape.memo_type,
@@ -283,10 +287,6 @@ export const authChallengeSchema = z.object({
   }, "callback_url must be a valid URL"),
   client_id: paymentBaseSchema.shape.client_id,
   metadata: z.unknown().optional(),
-    .refine(
-      (val) => val.startsWith("G") && val.length === 56,
-      "Invalid Stellar address",
-    ),
 });
 
 export const authVerifySchema = z.object({


### PR DESCRIPTION
## Summary

The webhook secret rotation feature (`POST /api/merchants/rotate-webhook-secret`) was already fully implemented:
- Generates a new `whsec_<hex64>` secret
- Saves the old secret to `webhook_secret_old` with a configurable grace period expiry (`webhook_secret_expiry`)
- `verifyWebhook()` accepts either secret during the grace window, preventing broken integrations on rotation

However, `merchants.test.js` was failing with **"Unexpected token `.`"** because `request-schemas.js` had a stray `.refine()` call that was syntactically invalid — it appeared after a property definition instead of being chained onto the `account` field where it belongs (Stellar G-address validation).

This PR fixes the orphaned `.refine()` so the rotation tests pass.

## Test plan

- [x] `merchants.test.js` — 2 rotation tests (default 24h grace, custom grace override) — now pass
- [x] `webhooks.test.js` — 15 tests including dual-secret verification during grace window — pass

Closes #407