### PR TITLE
feat: add display formatting toggle to strip trailing decimal zeroes

### DIFF
--- a/frontend/src/app/(authenticated)/settings/page.tsx
+++ b/frontend/src/app/(authenticated)/settings/page.tsx
@@ -13,6 +13,7 @@ import {
   useMerchantHydrated,
   useSetMerchantApiKey,
 } from "@/lib/merchant-store";
+import { useDisplayPreferences } from "@/lib/display-preferences";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000";
 const HEX_COLOR_REGEX = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/;
@@ -22,7 +23,7 @@ const DEFAULT_BRANDING = {
   background_color: "#050608",
 };
 
-type SettingsTab = "api" | "branding" | "webhooks" | "danger";
+type SettingsTab = "api" | "branding" | "display" | "webhooks" | "danger";
 
 interface WebhookDomainVerification {
   status: "verified" | "unverified";
@@ -141,6 +142,7 @@ export default function SettingsPage() {
   const [rotating, setRotating] = useState(false);
   const [rotateError, setRotateError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<SettingsTab>("api");
+  const { hideCents, setHideCents } = useDisplayPreferences();
   const [branding, setBranding] = useState(DEFAULT_BRANDING);
   const [brandingError, setBrandingError] = useState<string | null>(null);
   const [loadingBranding, setLoadingBranding] = useState(false);
@@ -539,6 +541,17 @@ export default function SettingsPage() {
           </button>
           <button
             type="button"
+            onClick={() => setActiveTab("display")}
+            className={`flex-1 rounded-lg px-4 py-2 text-sm font-medium ${
+              activeTab === "display"
+                ? "bg-white text-black"
+                : "text-slate-300 hover:bg-white/10"
+            }`}
+          >
+            Display
+          </button>
+          <button
+            type="button"
             onClick={() => setActiveTab("webhooks")}
             className={`flex-1 rounded-lg px-4 py-2 text-sm font-medium ${
               activeTab === "webhooks"
@@ -821,6 +834,36 @@ export default function SettingsPage() {
               </svg>
               Preview Receipt
             </button>
+          </section>
+        )}
+
+        {activeTab === "display" && (
+          <section className="flex flex-col gap-5">
+            <div className="flex flex-col gap-1">
+              <h2 className="text-xs font-medium uppercase tracking-wider text-slate-400">
+                Display Preferences
+              </h2>
+              <p className="text-sm text-slate-500">
+                Adjust how currency values appear in the dashboard.
+              </p>
+            </div>
+
+            <div className="rounded-2xl border border-white/10 bg-black/20 p-5">
+              <label className="flex items-start gap-3">
+                <input
+                  type="checkbox"
+                  checked={hideCents}
+                  onChange={(event) => setHideCents(event.target.checked)}
+                  className="mt-1 h-4 w-4 rounded border border-white/15 bg-black/40 text-mint focus:ring-mint"
+                />
+                <div className="space-y-1">
+                  <p className="font-semibold text-white">Hide trailing cents</p>
+                  <p className="text-sm text-slate-400">
+                    Whole amounts such as 50 will display without the .00 suffix.
+                  </p>
+                </div>
+              </label>
+            </div>
           </section>
         )}
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -8,6 +8,7 @@ import ToastProvider from "@/components/ToastProvider";
 import CommandPalette from "@/components/CommandPalette";
 import KeyboardShortcuts from "@/components/KeyboardShortcuts";
 import { WalletContextProvider } from "@/lib/wallet-context";
+import { DisplayPreferencesProvider } from "@/lib/display-preferences";
 import { Metadata, Viewport } from "next";
 
 const spaceGrotesk = Space_Grotesk({ subsets: ["latin"], variable: "--font-sans", display: "swap" });
@@ -60,14 +61,16 @@ export default async function RootLayout({ children }: { children: React.ReactNo
       <body className={`${spaceGrotesk.variable} ${spaceMono.variable} min-h-screen font-sans`}>
         <NextIntlClientProvider locale={locale} messages={messages}>
           <ThemeProvider>
-            <WalletContextProvider>
-              <ToastProvider />
-              <CommandPalette />
-              <KeyboardShortcuts />
-              <ErrorBoundary>
-                {children}
-              </ErrorBoundary>
-            </WalletContextProvider>
+            <DisplayPreferencesProvider>
+              <WalletContextProvider>
+                <ToastProvider />
+                <CommandPalette />
+                <KeyboardShortcuts />
+                <ErrorBoundary>
+                  {children}
+                </ErrorBoundary>
+              </WalletContextProvider>
+            </DisplayPreferencesProvider>
           </ThemeProvider>
         </NextIntlClientProvider>
       </body>

--- a/frontend/src/components/ActivityFeed.tsx
+++ b/frontend/src/components/ActivityFeed.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import Link from "next/link";
+import { useLocale } from "next-intl";
 import {
   useHydrateMerchantStore,
   useMerchantApiKey,
@@ -10,6 +11,10 @@ import {
   useMerchantId,
 } from "@/lib/merchant-store";
 import { usePaymentSocket } from "@/lib/usePaymentSocket";
+import {
+  useDisplayPreferences,
+  formatAmount,
+} from "@/lib/display-preferences";
 
 interface Payment {
   id: string;
@@ -28,6 +33,8 @@ export default function ActivityFeed() {
   const apiKey = useMerchantApiKey();
   const hydrated = useMerchantHydrated();
   const merchantId = useMerchantId();
+  const locale = useLocale();
+  const { hideCents } = useDisplayPreferences();
 
   useHydrateMerchantStore();
 
@@ -181,7 +188,7 @@ export default function ActivityFeed() {
               </div>
               <div className="text-right">
                 <p className="font-bold text-white">
-                  {payment.amount} {payment.asset}
+                  {formatAmount(payment.amount, locale, hideCents)} {payment.asset}
                 </p>
                 <p className="text-xs font-mono text-slate-400 uppercase">{payment.status}</p>
               </div>

--- a/frontend/src/components/AnalyticsCards.tsx
+++ b/frontend/src/components/AnalyticsCards.tsx
@@ -1,11 +1,16 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useLocale } from "next-intl";
 import {
   useHydrateMerchantStore,
   useMerchantApiKey,
   useMerchantHydrated,
 } from "@/lib/merchant-store";
+import {
+  useDisplayPreferences,
+  formatAmount,
+} from "@/lib/display-preferences";
 
 interface MetricsResponse {
   total_volume: number;
@@ -28,6 +33,8 @@ export default function AnalyticsCards() {
   
   const apiKey = useMerchantApiKey();
   const hydrated = useMerchantHydrated();
+  const locale = useLocale();
+  const { hideCents } = useDisplayPreferences();
 
   useHydrateMerchantStore();
 
@@ -93,7 +100,9 @@ export default function AnalyticsCards() {
           Total Volume (7D)
         </p>
         <div className="mt-4 flex items-baseline gap-2">
-          <p className="text-4xl font-bold text-mint">{totalVolume.toLocaleString()}</p>
+          <p className="text-4xl font-bold text-mint">
+            {formatAmount(totalVolume, locale, hideCents)}
+          </p>
           <p className="text-sm text-slate-400">XLM/USDC</p>
         </div>
       </div>

--- a/frontend/src/lib/display-preferences.tsx
+++ b/frontend/src/lib/display-preferences.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
+
+const STORAGE_KEY = "merchant-display-hide-cents";
+
+interface DisplayPreferencesContextValue {
+  hideCents: boolean;
+  setHideCents: (value: boolean) => void;
+}
+
+const DisplayPreferencesContext = createContext<DisplayPreferencesContextValue | null>(null);
+
+function parseHideCents(value: string | null): boolean {
+  return value === "true";
+}
+
+export function formatAmount(
+  value: number | string,
+  locale: string | undefined,
+  hideCents: boolean,
+) {
+  const number = typeof value === "string" ? Number(value) : value;
+  if (!Number.isFinite(number)) {
+    return String(value);
+  }
+
+  return new Intl.NumberFormat(locale, {
+    minimumFractionDigits: hideCents && Number.isInteger(number) ? 0 : 2,
+    maximumFractionDigits: 7,
+  }).format(number);
+}
+
+export function DisplayPreferencesProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [hideCents, setHideCents] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const storedValue = window.localStorage.getItem(STORAGE_KEY);
+    setHideCents(parseHideCents(storedValue));
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(STORAGE_KEY, String(hideCents));
+  }, [hideCents]);
+
+  const value = useMemo(
+    () => ({ hideCents, setHideCents }),
+    [hideCents],
+  );
+
+  return (
+    <DisplayPreferencesContext.Provider value={value}>
+      {children}
+    </DisplayPreferencesContext.Provider>
+  );
+}
+
+export function useDisplayPreferences() {
+  const context = useContext(DisplayPreferencesContext);
+  if (!context) {
+    throw new Error(
+      "useDisplayPreferences must be used within a DisplayPreferencesProvider",
+    );
+  }
+  return context;
+}


### PR DESCRIPTION
Closes #424

---

Add a dashboard setting to optionally hide trailing .00 in display amounts. Uses a local display preference persisted in localStorage.