### PR TITLE
feat(webhooks): Add 'Copy as cURL' to webhook logs

### DIFF
--- a/backend/sql/schema.sql
+++ b/backend/sql/schema.sql
@@ -44,6 +44,8 @@ create table if not exists webhook_delivery_logs (
   id uuid primary key default gen_random_uuid(),
   payment_id uuid references payments(id) on delete cascade,
   status_code integer not null,
+  request_payload jsonb,
+  request_headers jsonb,
   response_body text,
   timestamp timestamptz not null default now()
 );

--- a/backend/src/lib/webhooks.js
+++ b/backend/src/lib/webhooks.js
@@ -150,13 +150,15 @@ export function verifyWebhookWithTimestamp(rawBody, signatureHeader, timestamp, 
 /**
  * Log webhook delivery attempt to database
  */
-async function logWebhookDelivery(paymentId, statusCode, responseBody) {
+async function logWebhookDelivery(paymentId, statusCode, responseBody, requestPayload = null, requestHeaders = null) {
   if (!paymentId) return;
 
   try {
     await supabase.from("webhook_delivery_logs").insert({
       payment_id: paymentId,
       status_code: statusCode,
+      request_payload: requestPayload,
+      request_headers: requestHeaders,
       response_body: responseBody ? responseBody.substring(0, 1000) : null // Limit response body size
     });
   } catch (err) {
@@ -173,8 +175,8 @@ async function attempt(url, payload, headers, paymentId) {
 
   const text = await response.text().catch(() => "");
 
-  // Log the delivery attempt
-  await logWebhookDelivery(paymentId, response.status, text);
+  // Log the delivery attempt with request details
+  await logWebhookDelivery(paymentId, response.status, text, payload, headers);
 
   return { ok: response.ok, status: response.status, body: text };
 }
@@ -297,9 +299,9 @@ export async function sendWebhook(url, payload, secret, paymentId = null, custom
   } catch (err) {
     console.error(`Webhook to ${url} encountered an error: ${err.message}. Scheduling retries.`);
 
-    // Log the error
+    // Log the error with request details
     if (paymentId) {
-      await logWebhookDelivery(paymentId, 0, err.message);
+      await logWebhookDelivery(paymentId, 0, err.message, payload, headers);
     }
 
     scheduleRetries(url, payload, headers, paymentId);

--- a/backend/src/services/merchantService.js
+++ b/backend/src/services/merchantService.js
@@ -357,6 +357,8 @@ export const merchantService = {
         id,
         payment_id,
         status_code,
+        request_payload,
+        request_headers,
         response_body,
         timestamp,
         payments!inner(merchant_id, amount, asset, status)
@@ -410,6 +412,8 @@ export const merchantService = {
       payment_id: log.payment_id,
       status_code: log.status_code,
       success: log.status_code >= 200 && log.status_code < 300,
+      request_payload: log.request_payload,
+      request_headers: log.request_headers,
       response_body: log.response_body,
       timestamp: log.timestamp,
       payment: {

--- a/frontend/src/components/PaymentDetailsSheet.tsx
+++ b/frontend/src/components/PaymentDetailsSheet.tsx
@@ -6,6 +6,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { useMerchantApiKey } from "@/lib/merchant-store";
 import { localeToLanguageTag } from "@/i18n/config";
 import { InfoTooltip } from "@/components/InfoTooltip";
+import WebhookDetailModal, { WebhookLog } from "./WebhookDetailModal";
 
 interface PaymentDetails {
   id: string;
@@ -22,15 +23,7 @@ interface PaymentDetails {
   created_at: string;
 }
 
-interface WebhookLog {
-  id: string;
-  event_type: string;
-  payload: unknown;
-  status: number;
-  response_body: string | null;
-  url: string;
-  created_at: string;
-}
+
 
 interface PaymentDetailsSheetProps {
   paymentId: string;
@@ -49,6 +42,7 @@ export default function PaymentDetailsSheet({
   const apiKey = useMerchantApiKey();
   const [payment, setPayment] = useState<PaymentDetails | null>(null);
   const [webhookLogs, setWebhookLogs] = useState<WebhookLog[]>([]);
+  const [viewingLog, setViewingLog] = useState<WebhookLog | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<"details" | "metadata" | "webhooks">("details");
@@ -247,14 +241,18 @@ export default function PaymentDetailsSheet({
                         ) : (
                           <div className="divide-y divide-white/5">
                             {webhookLogs.map((log: WebhookLog) => (
-                              <div key={log.id} className="py-3">
+                              <div 
+                                key={log.id} 
+                                className="py-3 cursor-pointer hover:bg-white/5 transition-colors rounded-lg px-2 -mx-2"
+                                onClick={() => setViewingLog(log)}
+                              >
                                 <div className="flex items-center justify-between">
-                                  <span className="text-xs font-mono text-white">{log.event_type}</span>
-                                  <span className={`text-[10px] font-bold ${log.status >= 200 && log.status < 300 ? 'text-green-400' : 'text-red-400'}`}>
-                                    HTTP {log.status}
+                                  <span className="text-xs font-mono text-white">{log.event || log.id}</span>
+                                  <span className={`text-[10px] font-bold ${log.status_code >= 200 && log.status_code < 300 ? 'text-green-400' : 'text-red-400'}`}>
+                                    HTTP {log.status_code}
                                   </span>
                                 </div>
-                                <p className="mt-1 text-[10px] text-slate-500">{new Date(log.created_at).toLocaleString(locale)}</p>
+                                <p className="mt-1 text-[10px] text-slate-500">{new Date(log.timestamp).toLocaleString(locale)}</p>
                               </div>
                             ))}
                           </div>
@@ -266,6 +264,11 @@ export default function PaymentDetailsSheet({
               </div>
             </div>
           </motion.div>
+          <WebhookDetailModal
+            isOpen={!!viewingLog}
+            onClose={() => setViewingLog(null)}
+            log={viewingLog}
+          />
         </>
       )}
     </AnimatePresence>

--- a/frontend/src/components/WebhookDetailModal.tsx
+++ b/frontend/src/components/WebhookDetailModal.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import React from "react";
+import { Modal } from "@/components/ui/Modal";
+import { Button } from "@/components/ui/Button";
+import CopyButton from "./CopyButton";
+
+export interface WebhookLog {
+  id: string;
+  payment_id: string;
+  status_code: number;
+  event: string | null;
+  url: string;
+  request_payload: any;
+  request_headers: Record<string, string> | null;
+  response_body: string | null;
+  timestamp: string;
+}
+
+interface WebhookDetailModalProps {
+  log: WebhookLog | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+function statusClasses(statusCode: number) {
+  if (statusCode >= 200 && statusCode < 300) {
+    return "bg-green-500/20 text-green-300 border border-green-500/40";
+  }
+  if (statusCode >= 400 && statusCode < 500) {
+    return "bg-red-500/20 text-red-300 border border-red-500/40";
+  }
+  return "bg-yellow-500/20 text-yellow-300 border border-yellow-500/40";
+}
+
+export default function WebhookDetailModal({
+  log,
+  isOpen,
+  onClose,
+}: WebhookDetailModalProps) {
+  const generateCurl = (log: WebhookLog) => {
+    const headers = log.request_headers || {};
+    const payload = JSON.stringify(log.request_payload || {}, null, 2);
+
+    let curl = `curl -X POST "${log.url}"`;
+    Object.entries(headers).forEach(([key, value]) => {
+      curl += ` \\\n  -H "${key}: ${value}"`;
+    });
+    curl += ` \\\n  -d '${payload}'`;
+    return curl;
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Webhook Delivery Detail"
+    >
+      {log && (
+        <div className="space-y-6">
+          <div className="flex items-center justify-between">
+            <div className="space-y-1">
+              <p className="text-xs font-medium uppercase tracking-wider text-slate-500">Event</p>
+              <p className="text-sm font-semibold text-white">{log.event || "—"}</p>
+            </div>
+            <div className="text-right space-y-1">
+              <p className="text-xs font-medium uppercase tracking-wider text-slate-500">Status</p>
+              <span className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${statusClasses(log.status_code)}`}>
+                HTTP {log.status_code}
+              </span>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <p className="text-xs font-medium uppercase tracking-wider text-slate-500">Endpoint</p>
+            <code className="block rounded-lg border border-white/10 bg-black/40 p-2 text-xs text-slate-300 break-all">
+              {log.url}
+            </code>
+          </div>
+
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-semibold text-white">Payload (Request Body)</p>
+              <div className="flex gap-2">
+                <div className="flex items-center gap-1.5 rounded-lg border border-white/10 bg-white/5 px-2 py-1">
+                  <span className="text-[10px] font-medium text-slate-400">cURL</span>
+                  <CopyButton text={generateCurl(log)} />
+                </div>
+                <div className="flex items-center gap-1.5 rounded-lg border border-white/10 bg-white/5 px-2 py-1">
+                  <span className="text-[10px] font-medium text-slate-400">JSON</span>
+                  <CopyButton text={JSON.stringify(log.request_payload, null, 2)} />
+                </div>
+              </div>
+            </div>
+            <pre className="max-h-60 overflow-auto rounded-xl border border-white/10 bg-black/40 p-4 text-xs text-sky-300 font-mono ring-1 ring-inset ring-white/5">
+              {JSON.stringify(log.request_payload || {}, null, 2)}
+            </pre>
+          </div>
+
+          {log.response_body && (
+            <div className="space-y-3">
+              <p className="text-sm font-semibold text-white">Server Response</p>
+              <div className="max-h-40 overflow-auto rounded-xl border border-white/10 bg-black/40 p-4 font-mono text-xs text-slate-400 ring-1 ring-inset ring-white/5">
+                {log.response_body}
+              </div>
+            </div>
+          )}
+
+          <div className="pt-2">
+            <Button
+              variant="secondary"
+              className="w-full text-slate-400"
+              onClick={onClose}
+            >
+              Close
+            </Button>
+          </div>
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/frontend/src/components/WebhookLogs.tsx
+++ b/frontend/src/components/WebhookLogs.tsx
@@ -4,20 +4,14 @@ import { useEffect, useState } from "react";
 import WebhookLogSkeleton from "./WebhookLogSkeleton";
 import toast from "react-hot-toast";
 import { Button } from "@/components/ui/Button";
+import WebhookDetailModal, { WebhookLog } from "./WebhookDetailModal";
 import {
   useHydrateMerchantStore,
   useMerchantApiKey,
   useMerchantHydrated,
 } from "@/lib/merchant-store";
 
-interface WebhookLog {
-  id: string;
-  payment_id: string;
-  status_code: number;
-  event: string | null;
-  url: string;
-  created_at: string;
-}
+
 
 function statusClasses(statusCode: number) {
   if (statusCode >= 200 && statusCode < 300) {
@@ -41,6 +35,7 @@ export default function WebhookLogs() {
 
   const [logs, setLogs] = useState<WebhookLog[]>([]);
   const [selectedLogIds, setSelectedLogIds] = useState<string[]>([]);
+  const [viewingLog, setViewingLog] = useState<WebhookLog | null>(null);
   const [loading, setLoading] = useState(true);
   const [retrying, setRetrying] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -172,6 +167,8 @@ export default function WebhookLogs() {
     }
   };
 
+
+
   if (loading) {
     return <WebhookLogSkeleton />;
   }
@@ -258,8 +255,12 @@ export default function WebhookLogs() {
               const selected = selectedLogIds.includes(log.id);
 
               return (
-                <tr key={log.id} className="transition-colors hover:bg-white/5">
-                  <td className="px-4 py-3">
+                <tr 
+                  key={log.id} 
+                  className="group transition-colors hover:bg-white/5 cursor-pointer"
+                  onClick={() => setViewingLog(log)}
+                >
+                  <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
                     <input
                       type="checkbox"
                       className="h-4 w-4 rounded border-white/20 bg-transparent text-mint focus:ring-mint disabled:cursor-not-allowed disabled:opacity-40"
@@ -286,7 +287,7 @@ export default function WebhookLogs() {
                     {log.url}
                   </td>
                   <td className="hidden px-4 py-3 text-slate-400 md:table-cell">
-                    {new Date(log.created_at).toLocaleString()}
+                    {new Date(log.timestamp).toLocaleString()}
                   </td>
                 </tr>
               );
@@ -294,6 +295,12 @@ export default function WebhookLogs() {
           </tbody>
         </table>
       </div>
+
+      <WebhookDetailModal
+        isOpen={!!viewingLog}
+        onClose={() => setViewingLog(null)}
+        log={viewingLog}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Capture request payload and headers during webhook delivery attempts and store them in the database. Added a new WebhookDetailModal to the frontend to view these details and easily copy a valid cURL command for replaying webhooks locally.

Fixes #397