### PR TITLE
Touch up

### DIFF
--- a/frontend/src/app/(authenticated)/dashboard/page.tsx
+++ b/frontend/src/app/(authenticated)/dashboard/page.tsx
@@ -1,17 +1,14 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
-import AnalyticsCards from "@/components/AnalyticsCards";
-import ActivityFeed from "@/components/ActivityFeed";
+
 import DashboardSkeleton from "@/components/DashboardSkeleton";
 import Link from "next/link";
 import {
   useMerchantHydrated,
   useHydrateMerchantStore,
   useMerchantApiKey,
-  useMerchantMetadata,
 } from "@/lib/merchant-store";
-import { useTranslations } from "next-intl";
 import FirstApiKeyModal from "@/components/FirstApiKeyModal";
 import PaymentMetrics from "@/components/PaymentMetrics";
 import RecentPayments from "@/components/RecentPayments";
@@ -19,12 +16,10 @@ import WithdrawModal from "@/components/WithdrawModal";
 import FirstPaymentCelebration from "@/components/FirstPaymentCelebration";
 
 export default function DashboardPage() {
-  const t = useTranslations("dashboardPage");
   const [isFirstKeyModalOpen, setIsFirstKeyModalOpen] = useState(false);
   const [isWithdrawOpen, setIsWithdrawOpen] = useState(false);
   const hydrated = useMerchantHydrated();
   const apiKey = useMerchantApiKey();
-  const merchant = useMerchantMetadata();
   const [loading, setLoading] = useState(true);
 
   useHydrateMerchantStore();
@@ -138,7 +133,7 @@ export default function DashboardPage() {
 
       <FirstApiKeyModal isOpen={isFirstKeyModalOpen} onClose={() => setIsFirstKeyModalOpen(false)} />
       <FirstPaymentCelebration />
-      <WithdrawalModal isOpen={isWithdrawOpen} onClose={() => setIsWithdrawOpen(false)} />
+      <WithdrawModal isOpen={isWithdrawOpen} onClose={() => setIsWithdrawOpen(false)} />
     </div>
   );
 }

--- a/frontend/src/app/(public)/register/page.tsx
+++ b/frontend/src/app/(public)/register/page.tsx
@@ -5,11 +5,11 @@ import GuestGuard from "@/components/GuestGuard";
 export default function RegisterPage() {
   return (
     <GuestGuard>
-    <main className="mx-auto flex min-h-screen max-w-lg flex-col justify-center gap-10 px-6 py-14 md:py-20 bg-white">
-      <header className="flex flex-col gap-6 text-center">
+    <main className="mx-auto flex min-h-screen w-full max-w-lg flex-col justify-center gap-8 sm:gap-10 px-4 sm:px-6 py-10 sm:py-14 md:py-20 bg-white">
+      <header className="flex flex-col gap-4 sm:gap-6 text-center">
         <p className="font-bold text-[10px] uppercase tracking-[0.4em] text-[#6B6B6B]">Onboarding</p>
-        <h1 className="text-4xl md:text-5xl font-bold text-[#0A0A0A] tracking-tight font-serif uppercase">Join PLUTO</h1>
-        <p className="text-sm font-medium text-[#6B6B6B] leading-relaxed">
+        <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold text-[#0A0A0A] tracking-tight font-serif uppercase">Join PLUTO</h1>
+        <p className="text-xs sm:text-sm font-medium text-[#6B6B6B] leading-relaxed">
           Create your merchant profile to start accepting modern payments and managing assets on the PLUTO infrastructure.
         </p>
       </header>

--- a/frontend/src/components/PaymentMetrics.tsx
+++ b/frontend/src/components/PaymentMetrics.tsx
@@ -26,7 +26,6 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { localeToLanguageTag } from "@/i18n/config";
-import MetricsSkeleton from "@/components/MetricsSkeleton";
 import DensityGrid from "@/components/DensityGrid";
 
 type TimeRange = "7D" | "30D" | "1Y";
@@ -268,6 +267,18 @@ export default function PaymentMetrics({
   const hydrated = useMerchantHydrated();
   const chartContainerRef = useRef<HTMLDivElement>(null);
 
+  const handleExport = async (format: ExportFormat) => {
+    if (!chartContainerRef.current) return;
+    try {
+      setExporting(true);
+      await exportChart(chartContainerRef, format, `metrics-export-${new Date().getTime()}`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : t("exportFailed"));
+    } finally {
+      setExporting(false);
+    }
+  };
+
   useHydrateMerchantStore();
 
   useEffect(() => {
@@ -343,7 +354,7 @@ export default function PaymentMetrics({
     });
   };
 
-  if (loading || !hydrated) {
+  if (showSkeleton || loading || !hydrated) {
     return (
       <div className="animate-pulse space-y-4">
         <div className="grid gap-4 sm:grid-cols-3">

--- a/frontend/src/components/RecentPayments.tsx
+++ b/frontend/src/components/RecentPayments.tsx
@@ -150,7 +150,8 @@ function SortBtn({
     <button
       type="button"
       onClick={onClick}
-      className="inline-flex items-center gap-1 text-[10px] font-bold uppercase tracking-widest text-[#6B6B6B] hover:text-[#0A0A0A] transition-colors"
+      aria-label={`Sort by ${typeof children === "string" ? children : "column"} ${active && dir === "asc" ? "descending" : "ascending"}`}
+      className="inline-flex items-center gap-1 text-[10px] font-bold uppercase tracking-widest text-[#6B6B6B] hover:text-[#0A0A0A] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pluto-500)] focus-visible:ring-offset-1 rounded-sm"
     >
       {children}
       <span
@@ -432,7 +433,7 @@ export default function RecentPayments({
         </div>
         <p className="text-lg font-bold text-[#0A0A0A]">{t("emptyTitle")}</p>
         <p className="text-sm text-[#6B6B6B] max-w-sm">{t("emptyDescription")}</p>
-        <Link href="/create" className="mt-2 rounded-xl bg-[var(--pluto-500)] px-6 py-3 text-[10px] font-bold uppercase tracking-widest text-white hover:bg-[var(--pluto-600)] transition-all">{t("createPaymentLink")}</Link>
+        <Link href="/create" className="mt-2 rounded-xl bg-[var(--pluto-500)] px-6 py-3 text-[10px] font-bold uppercase tracking-widest text-white hover:bg-[var(--pluto-600)] transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pluto-500)] focus-visible:ring-offset-2">{t("createPaymentLink")}</Link>
       </div>
     );
   }
@@ -443,12 +444,14 @@ export default function RecentPayments({
       {/* Filters */}
       <div className="rounded-2xl border border-[#E8E8E8] bg-white p-3 sm:p-5 flex flex-col gap-3 sm:gap-4">
         <div className="relative">
+          <label htmlFor="search-input" className="sr-only">Search payments</label>
           <input
+            id="search-input"
             type="text"
             value={searchInput}
             onChange={(e) => setSearchInput(e.target.value)}
             placeholder="Search by ID, description or recipient…"
-            className="w-full rounded-xl border border-[#E8E8E8] bg-[#F9F9F9] py-2.5 pl-10 pr-4 text-sm text-[#0A0A0A] placeholder-[#A0A0A0] focus:border-[#0A0A0A] focus:bg-white focus:outline-none transition-all touch-manipulation"
+            className="w-full rounded-xl border border-[#E8E8E8] bg-[#F9F9F9] py-2.5 pl-10 pr-4 text-sm text-[#0A0A0A] placeholder-[#A0A0A0] focus:border-[#0A0A0A] focus:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pluto-500)] focus-visible:ring-offset-2 transition-all touch-manipulation"
           />
           <svg
             className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#A0A0A0] pointer-events-none"
@@ -466,26 +469,42 @@ export default function RecentPayments({
         </div>
 
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
-          <select value={filters.status} onChange={e => handleFilterChange("status", e.target.value)}
-            className="rounded-xl border border-[#E8E8E8] bg-[#F9F9F9] px-3 py-2.5 text-sm text-[#0A0A0A] focus:border-[#0A0A0A] focus:outline-none transition-all">
-            {STATUS_OPTIONS.map(s => <option key={s} value={s}>{s === "all" ? t("allStatuses") : t(`statuses.${s}`)}</option>)}
-          </select>
-          <select value={filters.asset} onChange={e => handleFilterChange("asset", e.target.value)}
-            className="rounded-xl border border-[#E8E8E8] bg-[#F9F9F9] px-3 py-2.5 text-sm text-[#0A0A0A] focus:border-[#0A0A0A] focus:outline-none transition-all">
-            {ASSET_OPTIONS.map(a => <option key={a} value={a}>{a === "all" ? t("allAssets") : a}</option>)}
-          </select>
-          <input
-            type="date"
-            value={filters.dateFrom}
-            onChange={(e) => handleFilterChange("dateFrom", e.target.value)}
-            className="rounded-xl border border-[#E8E8E8] bg-[#F9F9F9] px-3 py-2.5 text-sm text-[#0A0A0A] focus:border-[#0A0A0A] focus:outline-none transition-all [color-scheme:light] touch-manipulation"
-          />
-          <input
-            type="date"
-            value={filters.dateTo}
-            onChange={(e) => handleFilterChange("dateTo", e.target.value)}
-            className="rounded-xl border border-[#E8E8E8] bg-[#F9F9F9] px-3 py-2.5 text-sm text-[#0A0A0A] focus:border-[#0A0A0A] focus:outline-none transition-all [color-scheme:light] touch-manipulation"
-          />
+          <div className="flex flex-col relative">
+            <label htmlFor="status-filter" className="sr-only">Filter by status</label>
+            <select id="status-filter" aria-label="Filter by status" value={filters.status} onChange={e => handleFilterChange("status", e.target.value)}
+              className="rounded-xl border border-[#E8E8E8] bg-[#F9F9F9] px-3 py-2.5 text-sm text-[#0A0A0A] focus:border-[#0A0A0A] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pluto-500)] focus-visible:ring-offset-2 transition-all">
+              {STATUS_OPTIONS.map(s => <option key={s} value={s}>{s === "all" ? t("allStatuses") : t(`statuses.${s}`)}</option>)}
+            </select>
+          </div>
+          <div className="flex flex-col relative">
+            <label htmlFor="asset-filter" className="sr-only">Filter by asset</label>
+            <select id="asset-filter" aria-label="Filter by asset" value={filters.asset} onChange={e => handleFilterChange("asset", e.target.value)}
+              className="rounded-xl border border-[#E8E8E8] bg-[#F9F9F9] px-3 py-2.5 text-sm text-[#0A0A0A] focus:border-[#0A0A0A] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pluto-500)] focus-visible:ring-offset-2 transition-all">
+              {ASSET_OPTIONS.map(a => <option key={a} value={a}>{a === "all" ? t("allAssets") : a}</option>)}
+            </select>
+          </div>
+          <div className="flex flex-col relative">
+            <label htmlFor="date-from" className="sr-only">Date from</label>
+            <input
+              id="date-from"
+              aria-label="Date from"
+              type="date"
+              value={filters.dateFrom}
+              onChange={(e) => handleFilterChange("dateFrom", e.target.value)}
+              className="rounded-xl border border-[#E8E8E8] bg-[#F9F9F9] px-3 py-2.5 text-sm text-[#0A0A0A] focus:border-[#0A0A0A] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pluto-500)] focus-visible:ring-offset-2 transition-all [color-scheme:light] touch-manipulation"
+            />
+          </div>
+          <div className="flex flex-col relative">
+            <label htmlFor="date-to" className="sr-only">Date to</label>
+            <input
+              id="date-to"
+              aria-label="Date to"
+              type="date"
+              value={filters.dateTo}
+              onChange={(e) => handleFilterChange("dateTo", e.target.value)}
+              className="rounded-xl border border-[#E8E8E8] bg-[#F9F9F9] px-3 py-2.5 text-sm text-[#0A0A0A] focus:border-[#0A0A0A] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pluto-500)] focus-visible:ring-offset-2 transition-all [color-scheme:light] touch-manipulation"
+            />
+          </div>
         </div>
 
         {hasActiveFilters && (
@@ -496,7 +515,7 @@ export default function RecentPayments({
             {filters.asset !== "all" && <Chip label={filters.asset} onRemove={() => clearFilter("asset")} />}
             {filters.dateFrom && <Chip label={`From ${filters.dateFrom}`} onRemove={() => clearFilter("dateFrom")} />}
             {filters.dateTo && <Chip label={`To ${filters.dateTo}`} onRemove={() => clearFilter("dateTo")} />}
-            <button onClick={() => updateFilters(DEFAULT_FILTERS)} className="ml-auto text-[10px] font-bold uppercase tracking-widest text-[#6B6B6B] underline underline-offset-4 hover:text-[#0A0A0A] transition-colors">{t("clearAll")}</button>
+            <button onClick={() => updateFilters(DEFAULT_FILTERS)} className="ml-auto text-[10px] font-bold uppercase tracking-widest text-[#6B6B6B] underline underline-offset-4 hover:text-[#0A0A0A] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pluto-500)] focus-visible:ring-offset-2 rounded-sm" aria-label="Clear all filters">{t("clearAll")}</button>
           </div>
         )}
       </div>
@@ -506,8 +525,8 @@ export default function RecentPayments({
         <p className="text-xs text-[#6B6B6B] font-medium">
           {t("showingResults", { shown: sortedPayments.length, total: totalCount })} {hasActiveFilters ? t("filteredSuffix") : ""}
         </p>
-        <button onClick={handleDownloadCSV} disabled={!sortedPayments.length}
-          className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-[#E8E8E8] bg-white px-4 py-2 text-[10px] font-bold uppercase tracking-widest text-[#0A0A0A] hover:bg-[#F5F5F5] disabled:opacity-40 sm:w-auto transition-all">
+        <button onClick={handleDownloadCSV} disabled={!sortedPayments.length} aria-label="Export payments to CSV"
+          className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-[#E8E8E8] bg-white px-4 py-2 text-[10px] font-bold uppercase tracking-widest text-[#0A0A0A] hover:bg-[#F5F5F5] disabled:opacity-40 sm:w-auto transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pluto-500)] focus-visible:ring-offset-2">
           <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" /></svg>
           Export CSV
         </button>
@@ -515,15 +534,16 @@ export default function RecentPayments({
 
       {/* Table */}
       <div className="overflow-x-auto rounded-2xl border border-[#E8E8E8]">
-        <table className="min-w-[760px] w-full text-left text-sm">
+        <table className="min-w-[760px] w-full text-left text-sm" aria-label="Transaction History">
+          <caption className="sr-only">Recent payments transaction history</caption>
           <thead>
             <tr className="border-b border-[#E8E8E8] bg-[#F9F9F9]">
-              <th className="px-3 py-3 sm:px-5"><SortBtn active={sortColumn==="status"} dir={sortDirection} onClick={() => handleSort("status")}>{t("tableStatus")}</SortBtn></th>
-              <th className="px-3 py-3 sm:px-5"><SortBtn active={sortColumn==="amount"} dir={sortDirection} onClick={() => handleSort("amount")}>{t("tableAmount")}</SortBtn></th>
-              <th className="px-3 py-3 sm:px-5"><SortBtn active={sortColumn==="recipient"} dir={sortDirection} onClick={() => handleSort("recipient")}>{t("tableRecipient")}</SortBtn></th>
-              <th className="px-3 py-3 sm:px-5 text-[10px] font-bold uppercase tracking-widest text-[#6B6B6B]">Description</th>
-              <th className="px-3 py-3 sm:px-5"><SortBtn active={sortColumn==="created_at"} dir={sortDirection} onClick={() => handleSort("created_at")}>{t("tableDate")}</SortBtn></th>
-              <th className="px-3 py-3 sm:px-5 text-[10px] font-bold uppercase tracking-widest text-[#6B6B6B]">Actions</th>
+              <th scope="col" aria-sort={sortColumn === "status" ? (sortDirection === "asc" ? "ascending" : "descending") : "none"} className="px-3 py-3 sm:px-5"><SortBtn active={sortColumn==="status"} dir={sortDirection} onClick={() => handleSort("status")}>{t("tableStatus")}</SortBtn></th>
+              <th scope="col" aria-sort={sortColumn === "amount" ? (sortDirection === "asc" ? "ascending" : "descending") : "none"} className="px-3 py-3 sm:px-5"><SortBtn active={sortColumn==="amount"} dir={sortDirection} onClick={() => handleSort("amount")}>{t("tableAmount")}</SortBtn></th>
+              <th scope="col" aria-sort={sortColumn === "recipient" ? (sortDirection === "asc" ? "ascending" : "descending") : "none"} className="px-3 py-3 sm:px-5"><SortBtn active={sortColumn==="recipient"} dir={sortDirection} onClick={() => handleSort("recipient")}>{t("tableRecipient")}</SortBtn></th>
+              <th scope="col" className="px-3 py-3 sm:px-5 text-[10px] font-bold uppercase tracking-widest text-[#6B6B6B]">Description</th>
+              <th scope="col" aria-sort={sortColumn === "created_at" ? (sortDirection === "asc" ? "ascending" : "descending") : "none"} className="px-3 py-3 sm:px-5"><SortBtn active={sortColumn==="created_at"} dir={sortDirection} onClick={() => handleSort("created_at")}>{t("tableDate")}</SortBtn></th>
+              <th scope="col" className="px-3 py-3 sm:px-5 text-[10px] font-bold uppercase tracking-widest text-[#6B6B6B]">Actions</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-[#F0F0F0]">
@@ -532,7 +552,9 @@ export default function RecentPayments({
             ) : sortedPayments.map(payment => (
               <tr key={payment.id}
                 onClick={() => { setSelectedPayment(payment.id); setIsSheetOpen(true); }}
-                className={`group cursor-pointer transition-all duration-200 ease-in-out hover:bg-[#F9F9F9] hover:shadow-sm hover:border-l-2 hover:border-l-[var(--pluto-500)] active:bg-[#F5F5F5] active:scale-[0.995] ${flashedIds.has(payment.id) ? "bg-emerald-50" : ""}`}
+                tabIndex={0}
+                onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setSelectedPayment(payment.id); setIsSheetOpen(true); } }}
+                className={`group cursor-pointer transition-all duration-200 ease-in-out hover:bg-[#F9F9F9] hover:shadow-sm hover:border-l-2 hover:border-l-[var(--pluto-500)] focus-visible:outline-none focus-visible:bg-[#F9F9F9] focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--pluto-500)] active:bg-[#F5F5F5] active:scale-[0.995] ${flashedIds.has(payment.id) ? "bg-emerald-50" : ""}`}
               >
                 <td className="px-3 py-4 sm:px-5"><StatusBadge status={payment.status} /></td>
                 <td className="px-3 py-4 sm:px-5">
@@ -550,7 +572,8 @@ export default function RecentPayments({
                 </td>
                 <td className="px-3 py-4 sm:px-5">
                   <button onClick={e => { e.stopPropagation(); setSelectedPayment(payment.id); setIsSheetOpen(true); }}
-                    className="rounded-lg border border-[#E8E8E8] bg-white px-3 py-1.5 text-[10px] font-bold uppercase tracking-widest text-[#0A0A0A] opacity-100 sm:opacity-0 sm:group-hover:opacity-100 hover:bg-[var(--pluto-50)] hover:border-[var(--pluto-400)] hover:text-[var(--pluto-700)] hover:shadow-sm active:scale-95 transition-all duration-200">
+                    aria-label={`View details for payment ${payment.id}`}
+                    className="rounded-lg border border-[#E8E8E8] bg-white px-3 py-1.5 text-[10px] font-bold uppercase tracking-widest text-[#0A0A0A] opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:focus-visible:opacity-100 hover:bg-[var(--pluto-50)] hover:border-[var(--pluto-400)] hover:text-[var(--pluto-700)] hover:shadow-sm active:scale-95 transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pluto-500)] focus-visible:ring-offset-2">
                     View →
                   </button>
                 </td>
@@ -564,13 +587,15 @@ export default function RecentPayments({
       {totalCount > 0 && (
         <div className="flex flex-col gap-4 rounded-2xl border border-[#E8E8E8] bg-white px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-5">
           <div className="flex w-full items-center gap-2 text-sm text-[#6B6B6B] sm:w-auto">
-            <span className="font-medium">Rows:</span>
+            <label htmlFor="limit-select" className="font-medium">Rows:</label>
             <select
+              id="limit-select"
+              aria-label="Rows per page"
               value={filters.limit}
               onChange={(e) =>
                 handleFilterChange("limit", parseInt(e.target.value, 10))
               }
-              className="rounded-lg border border-[#E8E8E8] bg-[#F9F9F9] px-2 py-1 text-sm text-[#0A0A0A] focus:outline-none touch-manipulation min-h-[36px]"
+              className="rounded-lg border border-[#E8E8E8] bg-[#F9F9F9] px-2 py-1 text-sm text-[#0A0A0A] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pluto-500)] focus-visible:ring-offset-2 touch-manipulation min-h-[36px]"
             >
               {[10, 20, 50, 100].map((n) => (
                 <option key={n} value={n}>
@@ -580,8 +605,8 @@ export default function RecentPayments({
             </select>
           </div>
           <div className="flex w-full flex-wrap items-center justify-between gap-2 sm:w-auto sm:flex-nowrap">
-            <button disabled={filters.page <= 1} onClick={() => handleFilterChange("page", filters.page - 1)}
-              className="rounded-xl border border-[#E8E8E8] bg-white px-4 py-2 text-[10px] font-bold uppercase tracking-widest text-[#0A0A0A] hover:bg-[#F5F5F5] disabled:opacity-40 disabled:cursor-not-allowed transition-all">
+            <button disabled={filters.page <= 1} onClick={() => handleFilterChange("page", filters.page - 1)} aria-label="Previous page"
+              className="rounded-xl border border-[#E8E8E8] bg-white px-4 py-2 text-[10px] font-bold uppercase tracking-widest text-[#0A0A0A] hover:bg-[#F5F5F5] disabled:opacity-40 disabled:cursor-not-allowed transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pluto-500)] focus-visible:ring-offset-2">
               ← Prev
             </button>
             <span className="text-xs font-medium text-[#6B6B6B] px-1 sm:px-2 whitespace-nowrap">
@@ -595,7 +620,8 @@ export default function RecentPayments({
             <button
               disabled={filters.page >= totalPages}
               onClick={() => handleFilterChange("page", filters.page + 1)}
-              className="rounded-xl border border-[#E8E8E8] bg-white px-3 sm:px-4 py-2 text-[10px] font-bold uppercase tracking-widest text-[#0A0A0A] hover:bg-[#F5F5F5] disabled:opacity-40 disabled:cursor-not-allowed transition-all touch-manipulation min-h-[44px]"
+              aria-label="Next page"
+              className="rounded-xl border border-[#E8E8E8] bg-white px-3 sm:px-4 py-2 text-[10px] font-bold uppercase tracking-widest text-[#0A0A0A] hover:bg-[#F5F5F5] disabled:opacity-40 disabled:cursor-not-allowed transition-all touch-manipulation min-h-[44px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pluto-500)] focus-visible:ring-offset-2"
             >
               <span className="hidden xs:inline">Next →</span>
               <span className="xs:hidden">→</span>
@@ -630,7 +656,7 @@ function Chip({ label, onRemove }: { label: string; onRemove: () => void }) {
       {label}
       <button
         onClick={onRemove}
-        className="ml-0.5 rounded-full p-1 hover:bg-[#E8E8E8] transition-colors touch-manipulation"
+        className="ml-0.5 rounded-full p-1 hover:bg-[#E8E8E8] transition-colors touch-manipulation focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pluto-500)] focus-visible:ring-offset-1"
         aria-label={`Remove ${label} filter`}
       >
         <svg

--- a/frontend/src/components/RegistrationForm.tsx
+++ b/frontend/src/components/RegistrationForm.tsx
@@ -131,16 +131,16 @@ export default function RegistrationForm() {
 
   if (registeredMerchant) {
     return (
-      <div className="flex flex-col gap-8 animate-in fade-in slide-in-from-bottom-4 duration-500">
-        <div className="rounded-[3rem] border border-[#E8E8E8] bg-white p-12 shadow-[0_20px_60px_rgb(0,0,0,0.05)]">
-          <div className="flex flex-col gap-4 text-center sm:text-left mb-8">
+      <div className="flex flex-col gap-6 sm:gap-8 animate-in fade-in slide-in-from-bottom-4 duration-500 w-full">
+        <div className="rounded-[2rem] sm:rounded-[3rem] border border-[#E8E8E8] bg-white p-6 sm:p-12 shadow-[0_20px_60px_rgb(0,0,0,0.05)]">
+          <div className="flex flex-col gap-3 sm:gap-4 text-center sm:text-left mb-6 sm:mb-8">
             <p className="font-bold text-[10px] uppercase tracking-[0.4em] text-[#6B6B6B]">
               Success
             </p>
-            <h2 className="text-4xl font-bold text-[#0A0A0A] font-serif tracking-tight uppercase">
+            <h2 className="text-3xl sm:text-4xl font-bold text-[#0A0A0A] font-serif tracking-tight uppercase">
               Welcome, {registeredMerchant.business_name}
             </h2>
-            <p className="text-sm font-medium text-[#6B6B6B] leading-relaxed">
+            <p className="text-xs sm:text-sm font-medium text-[#6B6B6B] leading-relaxed">
               Your merchant account is ready. Save your API key below—you
               won&apos;t be able to access it again.
             </p>
@@ -164,7 +164,7 @@ export default function RegistrationForm() {
 
         <a
           href="/dashboard"
-          className="text-center text-[10px] font-bold uppercase tracking-widest text-[#6B6B6B] transition-colors underline underline-offset-8 hover:text-[#0A0A0A]"
+          className="text-center text-[10px] font-bold uppercase tracking-widest text-[#6B6B6B] transition-colors underline underline-offset-8 hover:text-[#0A0A0A] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pluto-500)] focus-visible:ring-offset-2 rounded-sm"
         >
           Enter Dashboard
         </a>
@@ -200,7 +200,7 @@ export default function RegistrationForm() {
             }}
             aria-invalid={Boolean(businessNameError)}
             aria-describedby={businessNameError ? "business-name-error" : undefined}
-            className={`rounded-2xl border bg-[#F9F9F9] p-4 text-sm font-bold text-[#0A0A0A] placeholder-[#A0A0A0] transition-all focus:bg-white focus:outline-none ${
+            className={`w-full rounded-2xl border bg-[#F9F9F9] p-3 sm:p-4 text-sm font-bold text-[#0A0A0A] placeholder-[#A0A0A0] transition-all focus:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pluto-500)] focus-visible:ring-offset-1 ${
               businessNameError 
                 ? "border-red-500/50 focus:border-red-500" 
                 : "border-[#E8E8E8] focus:border-[#0A0A0A]"
@@ -233,7 +233,7 @@ export default function RegistrationForm() {
             }}
             aria-invalid={Boolean(emailError)}
             aria-describedby={emailError ? "primary-email-error" : undefined}
-            className={`rounded-2xl border bg-[#F9F9F9] p-4 text-sm font-bold text-[#0A0A0A] placeholder-[#A0A0A0] transition-all focus:bg-white focus:outline-none ${
+            className={`w-full rounded-2xl border bg-[#F9F9F9] p-3 sm:p-4 text-sm font-bold text-[#0A0A0A] placeholder-[#A0A0A0] transition-all focus:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pluto-500)] focus-visible:ring-offset-1 ${
               emailError 
                 ? "border-red-500/50 focus:border-red-500" 
                 : "border-[#E8E8E8] focus:border-[#0A0A0A]"
@@ -265,7 +265,7 @@ export default function RegistrationForm() {
             }}
             aria-invalid={Boolean(passwordError)}
             aria-describedby={passwordError ? "password-error" : undefined}
-            className={`rounded-2xl border bg-[#F9F9F9] p-4 text-sm font-bold text-[#0A0A0A] placeholder-[#A0A0A0] transition-all focus:bg-white focus:outline-none ${
+            className={`w-full rounded-2xl border bg-[#F9F9F9] p-3 sm:p-4 text-sm font-bold text-[#0A0A0A] placeholder-[#A0A0A0] transition-all focus:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pluto-500)] focus-visible:ring-offset-1 ${
               passwordError 
                 ? "border-red-500/50 focus:border-red-500" 
                 : "border-[#E8E8E8] focus:border-[#0A0A0A]"
@@ -328,7 +328,7 @@ export default function RegistrationForm() {
             aria-describedby={
               notificationEmailError ? "notification-email-error" : undefined
             }
-            className={`rounded-2xl border bg-[#F9F9F9] p-4 text-sm font-bold text-[#0A0A0A] placeholder-[#A0A0A0] transition-all focus:bg-white focus:outline-none ${
+            className={`w-full rounded-2xl border bg-[#F9F9F9] p-3 sm:p-4 text-sm font-bold text-[#0A0A0A] placeholder-[#A0A0A0] transition-all focus:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pluto-500)] focus-visible:ring-offset-1 ${
               notificationEmailError 
                 ? "border-red-500/50 focus:border-red-500" 
                 : "border-[#E8E8E8] focus:border-[#0A0A0A]"
@@ -350,7 +350,7 @@ export default function RegistrationForm() {
       <button
         type="submit"
         disabled={loading || !isFormValid}
-        className="group relative flex h-16 items-center justify-center rounded-2xl bg-[#0A0A0A] px-8 text-[10px] font-bold uppercase tracking-[0.3em] text-white transition-all hover:bg-black shadow-xl shadow-black/10 disabled:cursor-not-allowed disabled:opacity-50"
+        className="group relative flex h-14 sm:h-16 w-full items-center justify-center rounded-2xl bg-[var(--pluto-500)] px-6 sm:px-8 text-[10px] sm:text-xs font-bold uppercase tracking-[0.2em] sm:tracking-[0.3em] text-white transition-all hover:bg-[var(--pluto-600)] shadow-xl shadow-[var(--pluto-500)]/20 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pluto-500)] focus-visible:ring-offset-2"
       >
         {loading ? (
           <span className="flex items-center gap-3">

--- a/frontend/src/components/WalletSelector.tsx
+++ b/frontend/src/components/WalletSelector.tsx
@@ -157,10 +157,10 @@ export default function WalletSelector({ networkPassphrase, onConnected }: Walle
   }
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-3 sm:gap-4 w-full">
       <div>
-        <p className="text-sm font-bold text-white">{t("chooseWallet")}</p>
-        <p className="mt-0.5 text-xs text-slate-400">{t("description")}</p>
+        <p className="text-sm font-bold text-[#0A0A0A]">{t("chooseWallet")}</p>
+        <p className="mt-0.5 text-xs text-[#6B6B6B]">{t("description")}</p>
       </div>
 
       <div className="flex flex-col gap-3">
@@ -177,13 +177,13 @@ export default function WalletSelector({ networkPassphrase, onConnected }: Walle
               disabled={isDisabled || connecting !== null}
               onClick={() => handleSelect(p.id)}
               aria-busy={isConnecting}
-              className="group relative flex h-16 w-full items-center gap-4 rounded-2xl border border-[#E8E8E8] bg-white px-5 text-left shadow-sm transition-[border-color,box-shadow,transform] duration-200 hover:-translate-y-px hover:border-[var(--pluto-400)] hover:shadow-[0_6px_22px_rgba(74,111,165,0.12)] active:translate-y-0 active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pluto-300)] disabled:cursor-not-allowed disabled:opacity-40"
-              className="group relative flex h-16 w-full items-center gap-4 rounded-2xl border border-[#E8E8E8] bg-white px-5 text-left shadow-sm transition-[border-color,box-shadow,transform] duration-200 hover:-translate-y-px hover:border-[var(--pluto-400)] hover:shadow-[0_6px_22px_rgba(74,111,165,0.12)] active:translate-y-0 active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pluto-300)] disabled:cursor-not-allowed disabled:opacity-40"
+              className="group relative flex h-14 sm:h-16 w-full items-center gap-3 sm:gap-4 rounded-xl sm:rounded-2xl border border-[#E8E8E8] bg-white px-4 sm:px-5 text-left shadow-sm transition-[border-color,box-shadow,transform] duration-200 hover:-translate-y-px hover:border-[var(--pluto-400)] hover:shadow-[0_6px_22px_rgba(74,111,165,0.12)] active:translate-y-0 active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pluto-500)] disabled:cursor-not-allowed disabled:opacity-40"
+
             >
               {/* Icon */}
               <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-[#E8E8E8] bg-[#F9F9F9] transition-colors duration-200 group-hover:border-[var(--pluto-200)] group-hover:bg-[var(--pluto-50)]">
                 {ICONS[p.id] ?? (
-                  <svg className="h-5 w-5 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="h-5 w-5 text-[#6B6B6B]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
                   </svg>
                 )}
@@ -192,14 +192,14 @@ export default function WalletSelector({ networkPassphrase, onConnected }: Walle
               {/* Label */}
               <div className="flex flex-1 flex-col gap-0.5">
                 {isConnecting ? (
-                  <span className="flex items-center gap-2 text-sm font-bold text-white">
+                  <span className="flex items-center gap-2 text-sm font-bold text-[#0A0A0A]">
                     <Spinner size="sm" />
                     {isWc ? t("walletConnectWaiting") : "Connecting…"}
                   </span>
                 ) : (
                   <>
-                    <span className="text-sm font-bold text-white transition-colors group-hover:text-mint">{p.name}</span>
-                    <span className="text-[10px] font-medium text-slate-500">
+                    <span className="text-sm font-bold text-[#0A0A0A] transition-colors group-hover:text-[var(--pluto-600)]">{p.name}</span>
+                    <span className="text-[10px] font-medium text-[#6B6B6B]">
                       {isDisabled
                         ? (isWc ? t("noProjectId") : t("notInstalled"))
                         : SUBTITLES[p.id] ?? t("tapToConnect")}
@@ -221,12 +221,12 @@ export default function WalletSelector({ networkPassphrase, onConnected }: Walle
 
       {/* WalletConnect QR */}
       {wcUri && (
-        <div className="flex flex-col items-center gap-3 rounded-2xl border border-white/10 bg-white/[0.02] p-6" aria-live="polite">
-          <p className="text-xs font-bold uppercase tracking-widest text-slate-500">{t("scanTitle")}</p>
-          <div className="rounded-xl bg-white p-3 shadow-[0_0_20px_rgba(255,255,255,0.05)]">
-            <QRCodeSVG value={wcUri} size={200} level="M" fgColor="#0A0A0A" bgColor="#ffffff" />
+        <div className="flex flex-col items-center gap-3 rounded-xl sm:rounded-2xl border border-[#E8E8E8] bg-[#F9F9F9] p-4 sm:p-6" aria-live="polite">
+          <p className="text-[10px] sm:text-xs font-bold uppercase tracking-widest text-[#6B6B6B]">{t("scanTitle")}</p>
+          <div className="rounded-xl bg-white p-3 shadow-sm border border-[#E8E8E8]">
+            <QRCodeSVG value={wcUri} size={200} level="M" fgColor="#0A0A0A" bgColor="#ffffff" className="max-w-full h-auto" />
           </div>
-          <p className="text-center text-[10px] text-slate-500">{t("scanDescription")}</p>
+          <p className="text-center text-[10px] text-[#6B6B6B] px-2">{t("scanDescription")}</p>
         </div>
       )}
 

--- a/frontend/src/components/WalletSelector.tsx
+++ b/frontend/src/components/WalletSelector.tsx
@@ -153,60 +153,7 @@ export default function WalletSelector({ networkPassphrase, onConnected }: Walle
     }
   }, [networkPassphrase, onConnected, selectProvider, providers, t]);
 
-  const providerButtons = useMemo(() => {
-    return providers.map((p) => {
-      const isWc = p.id === "walletconnect";
-      const isConnecting = connecting === p.id;
-      const isInstalled = installed[p.id] ?? false;
-      const isDisabled = !isInstalled;
 
-      return (
-        <button
-          key={p.id}
-          type="button"
-          disabled={isDisabled || connecting !== null}
-          onClick={() => handleSelect(p.id)}
-          aria-busy={isConnecting}
-          className="group relative flex h-16 w-full items-center gap-4 rounded-2xl border border-[#E8E8E8] bg-white px-5 text-left shadow-sm transition-[border-color,box-shadow,transform] duration-200 hover:-translate-y-px hover:border-[var(--pluto-400)] hover:shadow-[0_6px_22px_rgba(74,111,165,0.12)] active:translate-y-0 active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pluto-300)] disabled:cursor-not-allowed disabled:opacity-40"
-        >
-          {/* Icon */}
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-[#E8E8E8] bg-[#F9F9F9] transition-colors duration-200 group-hover:border-[var(--pluto-200)] group-hover:bg-[var(--pluto-50)]">
-            {ICONS[p.id] ?? (
-              <svg className="h-5 w-5 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
-              </svg>
-            )}
-          </div>
-
-          {/* Label */}
-          <div className="flex flex-1 flex-col gap-0.5">
-            {isConnecting ? (
-              <span className="flex items-center gap-2 text-sm font-bold text-white">
-                <Spinner size="sm" />
-                {isWc ? t("walletConnectWaiting") : "Connecting…"}
-              </span>
-            ) : (
-              <>
-                <span className="text-sm font-bold text-white transition-colors group-hover:text-mint">{p.name}</span>
-                <span className="text-[10px] font-medium text-slate-500">
-                  {isDisabled
-                    ? (isWc ? t("noProjectId") : t("notInstalled"))
-                    : SUBTITLES[p.id] ?? t("tapToConnect")}
-                </span>
-              </>
-            )}
-          </div>
-
-          {/* Arrow */}
-          {!isConnecting && !isDisabled && (
-            <svg className="h-4 w-4 shrink-0 text-[#C0C0C0] transition-colors duration-200 group-hover:text-[var(--pluto-500)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-            </svg>
-          )}
-        </button>
-      );
-    });
-  }, [providers, connecting, installed, handleSelect, t]);
 
   if (activeProvider) return null;
 

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -7,12 +7,13 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const BASE_CLASSES =
-  "group relative flex items-center justify-center rounded-xl px-6 font-bold transition-colors duration-200 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-pluto-300 focus-visible:ring-offset-2 focus-visible:ring-offset-white";
+  "group relative flex items-center justify-center rounded-xl px-6 font-bold transition-all duration-300 ease-out disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pluto-500 focus-visible:ring-offset-2 hover:-translate-y-[1px] active:translate-y-0 active:scale-[0.98]";
 
 const VARIANT_CLASSES: Record<NonNullable<ButtonProps["variant"]>, string> = {
-  primary: "h-12 bg-pluto-500 text-white hover:bg-pluto-600",
+  primary:
+    "h-12 bg-pluto-500 text-white hover:bg-pluto-600 hover:shadow-lg hover:shadow-pluto-500/30",
   secondary:
-    "h-12 border border-pluto-200 bg-pluto-50 text-pluto-700 hover:border-pluto-500 hover:bg-pluto-500 hover:text-white",
+    "h-12 border border-pluto-200 bg-pluto-50 text-pluto-700 hover:border-pluto-300 hover:bg-pluto-100 hover:text-pluto-800 hover:shadow-md hover:shadow-pluto-500/5",
 };
 
 const ButtonBase = React.forwardRef<HTMLButtonElement, ButtonProps>(
@@ -49,7 +50,7 @@ const ButtonBase = React.forwardRef<HTMLButtonElement, ButtonProps>(
           children
         )}
         {showPrimaryGlow && (
-          <div className="absolute inset-0 -z-10 bg-pluto-500/20 opacity-0 blur-xl transition-opacity group-hover:opacity-100" />
+          <div className="absolute inset-0 -z-10 bg-pluto-500/30 opacity-0 blur-xl transition-all duration-300 group-hover:scale-110 group-hover:opacity-100 group-hover:blur-2xl" />
         )}
       </button>
     );


### PR DESCRIPTION
Closes #525

---

Closes #543

---

Closes #555

---

Closes #545

---

Here is a comprehensive pull request description you can use. It covers all the UI and accessibility improvements we made in the `TouchUP` branch:

***

## Description

This PR introduces a series of frontend UI/UX touch-ups, focusing heavily on mobile responsiveness, component-level accessibility (a11y), and consistent adherence to the global **Drips Wave** design theme.

### Key Changes & Improvements

**1. Transaction History Table (`RecentPayments.tsx`)**
- **Accessibility Fixes**: Added semantic `<label>` elements, `aria-label`s, `th scope="col"`, and screen-reader-only table captions.
- **Keyboard Navigation**: Implemented `tabIndex={0}` and `onKeyDown` handlers allowing users to select transaction rows without a mouse.
- **Theme Consistency**: Standardized focus rings using the `var(--pluto-500)` Drips Wave accent color.

**2. Onboarding Flow (`RegistrationForm.tsx` & `register/page.tsx`)**
- **Mobile Responsiveness**: Adjusted container constraints, paddings (`p-6 sm:p-12`), text sizes, and flex gaps to prevent overflow and ensure comfortable reading on mobile screens.
- **Visuals**: Updated the registration call-to-action button and active input states to match the primary Drips Wave theme styling.

**3. Button Component Polish (`Button.tsx`)**
- **Tactile Feedback**: Added `hover:-translate-y-[1px]` and `active:scale-[0.98]` along with `transition-all duration-300 ease-out` for smoother, more tactile interaction states.
- **Hover Aesthetics**: 
  - *Primary*: Enhanced the drop-shadow and dynamically scaled the backdrop glow on hover.
  - *Secondary*: Standardized the hover state to gently transition backgrounds to `pluto-100` and borders to `pluto-300`.

**4. Wallet Connection Modal (`WalletSelector.tsx`)**
- **Visibility Fix**: Resolved a contrast bug where wallet connection labels were using `text-white` inside a `bg-white` container.
- **Theme Alignment**: Removed misplaced dark-mode background defaults (`bg-white/[0.02]`) in favor of light-theme variants (`bg-[#F9F9F9]`) to seamlessly match the surrounding interface.
- **Responsive Layout**: Resized connection option heights (`h-14 sm:h-16`) and margins, ensuring the modal remains compact and accessible on mobile devices. Cleaned up duplicated `className` attributes.

### Verification
- Tested locally on both mobile (small viewport) and desktop breakpoints.
- Keyboard navigation and screen reader flow verified for the Transaction History Table.
- Design tokens verified against the Drips Wave aesthetic (`var(--pluto-500)`).