### PR TITLE
fix(frontend): enhance command palette actions for issue #518

### DIFF
--- a/frontend/src/components/CommandPalette.test.ts
+++ b/frontend/src/components/CommandPalette.test.ts
@@ -1,82 +1,54 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
+import { filterPaletteCommands, paletteCommands } from "./commandPaletteData";
 
-// ── Replicate the filter logic from CommandPalette.tsx ─────────────────────
-// (Pure function — no React needed)
+describe("Command palette data", () => {
+  it("contains required quick actions", () => {
+    const ids = paletteCommands.map((command) => command.id);
+    expect(ids).toContain("create-new-payment");
+    expect(ids).toContain("copy-api-key");
+    expect(ids).toContain("toggle-theme");
+  });
 
-interface Command {
-  id: string;
-  label: string;
-  description: string;
-  href: string;
-  keywords: string[];
-}
+  it("contains required high-level navigation routes", () => {
+    const commandById = new Map(paletteCommands.map((command) => [command.id, command]));
 
-const commands: Command[] = [
-  { id: "dashboard", label: "Dashboard", description: "View payments, metrics and activity", href: "/dashboard", keywords: ["dashboard", "home", "overview", "payments", "activity"] },
-  { id: "api-keys", label: "API Keys", description: "Manage and rotate your API keys", href: "/settings#api-keys", keywords: ["api", "keys", "key", "rotate", "secret", "token"] },
-  { id: "webhooks", label: "Webhooks", description: "Configure webhook URL and view delivery logs", href: "/settings#webhooks", keywords: ["webhook", "webhooks", "delivery", "logs", "url", "endpoint"] },
-  { id: "settings", label: "Settings", description: "API keys, webhook URL & merchant config", href: "/settings", keywords: ["settings", "config", "api", "keys", "webhook", "merchant"] },
-  { id: "create-payment", label: "Create Payment", description: "Generate a new Stellar payment link", href: "/dashboard/create", keywords: ["create", "payment", "new", "link", "pay", "generate"] },
-  { id: "home", label: "Home", description: "Return to the landing page", href: "/", keywords: ["home", "landing", "dashboard", "main"] },
-  { id: "register", label: "Register Merchant", description: "Register a new merchant account", href: "/register", keywords: ["register", "merchant", "signup", "account", "new"] },
-];
+    expect(commandById.get("dashboard")?.href).toBe("/dashboard");
+    expect(commandById.get("settings")?.href).toBe("/settings");
+    expect(commandById.get("docs")?.href).toBe("/docs");
+  });
+});
 
-function filterCommands(query: string): Command[] {
-  if (query.length === 0) return commands;
-  const q = query.toLowerCase();
-  return commands.filter(
-    (cmd) =>
-      cmd.label.toLowerCase().includes(q) ||
-      cmd.description.toLowerCase().includes(q) ||
-      cmd.keywords.some((kw) => kw.includes(q)),
-  );
-}
-
-// ── Tests ──────────────────────────────────────────────────────────────────
-
-describe("CommandPalette fuzzy search", () => {
+describe("Command palette fuzzy search", () => {
   it("returns all commands when query is empty", () => {
-    expect(filterCommands("").length).toBe(commands.length);
+    expect(filterPaletteCommands("")).toHaveLength(paletteCommands.length);
   });
 
-  it("matches by label (case-insensitive)", () => {
-    const results = filterCommands("DASHBOARD");
-    expect(results.map((c) => c.id)).toContain("dashboard");
+  it("finds create payment with fuzzy query", () => {
+    const results = filterPaletteCommands("crt pmt");
+    expect(results.map((command) => command.id)).toContain("create-new-payment");
   });
 
-  it("matches by description substring", () => {
-    const results = filterCommands("delivery logs");
-    expect(results.map((c) => c.id)).toContain("webhooks");
+  it("finds copy API key with fuzzy query", () => {
+    const results = filterPaletteCommands("cpy key");
+    expect(results.map((command) => command.id)).toContain("copy-api-key");
   });
 
-  it("matches by keyword", () => {
-    const results = filterCommands("rotate");
-    expect(results.map((c) => c.id)).toContain("api-keys");
+  it("finds theme toggle with fuzzy query", () => {
+    const results = filterPaletteCommands("tgle thm");
+    expect(results.map((command) => command.id)).toContain("toggle-theme");
   });
 
-  it("returns empty array for unrecognised query", () => {
-    expect(filterCommands("xyzzy-nonexistent-term")).toHaveLength(0);
+  it("finds help topics", () => {
+    const results = filterPaletteCommands("help hmac");
+    expect(results.map((command) => command.id)).toContain("help-hmac-signatures");
   });
 
-  it("navigates to correct href for Dashboard", () => {
-    const dash = commands.find((c) => c.id === "dashboard");
-    expect(dash?.href).toBe("/dashboard");
+  it("returns docs as top result for docs query", () => {
+    const results = filterPaletteCommands("docs");
+    expect(results[0]?.id).toBe("docs");
   });
 
-  it("navigates to correct href for API Keys", () => {
-    const keys = commands.find((c) => c.id === "api-keys");
-    expect(keys?.href).toBe("/settings#api-keys");
-  });
-
-  it("navigates to correct href for Webhooks", () => {
-    const hooks = commands.find((c) => c.id === "webhooks");
-    expect(hooks?.href).toBe("/settings#webhooks");
-  });
-
-  it("'web' matches both webhooks and settings", () => {
-    const results = filterCommands("web");
-    const ids = results.map((c) => c.id);
-    expect(ids).toContain("webhooks");
-    expect(ids).toContain("settings");
+  it("returns empty array for unmatched query", () => {
+    expect(filterPaletteCommands("zzqv unmatched command")).toHaveLength(0);
   });
 });

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -1,22 +1,25 @@
 "use client";
 
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import AssetConverter from "@/components/AssetConverter";
+import { useMerchantApiKey } from "@/lib/merchant-store";
+import { ThemeMode, useThemeActions, useThemeState } from "@/lib/theme-context";
+import { toast } from "sonner";
+import { filterPaletteCommands, PaletteCommand } from "@/components/commandPaletteData";
 
-/* ------------------------------------------------------------------ */
-/*  Command definitions                                                */
-/* ------------------------------------------------------------------ */
+const THEME_CYCLE: ThemeMode[] = ["light", "dark", "system"];
 
-type Command = {
-  id: string;
-  label: string;
-  description: string;
-  href?: string;
-  action?: string;
-  icon: React.ReactNode;
-  keywords: string[];
-};
+function getNextTheme(currentTheme: ThemeMode | undefined): ThemeMode {
+  const currentIndex = currentTheme ? THEME_CYCLE.indexOf(currentTheme) : -1;
+  const nextIndex = (currentIndex + 1 + THEME_CYCLE.length) % THEME_CYCLE.length;
+  return THEME_CYCLE[nextIndex];
+}
+
+function getThemeLabel(themeMode: ThemeMode, resolvedTheme: "light" | "dark" | undefined): string {
+  if (themeMode !== "system") return themeMode;
+  return resolvedTheme ? `system (${resolvedTheme})` : "system";
+}
 
 const SettingsIcon = (
   <svg
@@ -64,7 +67,46 @@ const HomeIcon = (
   </svg>
 );
 
-const RegisterIcon = (
+const DocsIcon = (
+  <svg
+    viewBox="0 0 24 24"
+    className="h-5 w-5 text-[#A0A0A0]"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.8}
+  >
+    <path d="M4 4h9a3 3 0 0 1 3 3v13H7a3 3 0 0 0-3 3V4z" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M20 20h-4V7a3 3 0 0 1 3-3h1v16z" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+const ConverterIcon = (
+  <svg
+    viewBox="0 0 24 24"
+    className="h-5 w-5 text-[#A0A0A0]"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.8}
+  >
+    <path d="M2 17 12 7l10 10" strokeLinecap="round" strokeLinejoin="round" opacity={0.4} />
+    <path d="M2 12 12 2l10 10" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+const KeyIcon = (
+  <svg
+    viewBox="0 0 24 24"
+    className="h-5 w-5 text-[#A0A0A0]"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.8}
+  >
+    <circle cx="8" cy="12" r="3.5" />
+    <path d="M11.5 12H21M17 12v3M14 12v2" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+const ThemeIcon = (
   <svg
     viewBox="0 0 24 24"
     className="h-5 w-5 text-[#A0A0A0]"
@@ -73,90 +115,39 @@ const RegisterIcon = (
     strokeWidth={1.8}
   >
     <path
-      d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"
+      d="M21.75 15A9.75 9.75 0 1 1 9 2.25a7.5 7.5 0 0 0 12.75 12.75z"
       strokeLinecap="round"
       strokeLinejoin="round"
     />
-    <circle cx="9" cy="7" r="4" strokeLinecap="round" strokeLinejoin="round" />
-    <path d="M19 8v6M22 11h-6" strokeLinecap="round" strokeLinejoin="round" />
   </svg>
 );
 
-const commands: Command[] = [
-  {
-    id: "dashboard",
-    label: "Dashboard",
-    description: "View payments, metrics and activity",
-    href: "/dashboard",
-    icon: HomeIcon,
-    keywords: ["dashboard", "home", "overview", "payments", "activity"],
-  },
-  {
-    id: "api-keys",
-    label: "API Keys",
-    description: "Manage and rotate your API keys",
-    href: "/settings#api-keys",
-    icon: SettingsIcon,
-    keywords: ["api", "keys", "key", "rotate", "secret", "token"],
-  },
-  {
-    id: "webhooks",
-    label: "Webhooks",
-    description: "Configure webhook URL and view delivery logs",
-    href: "/settings#webhooks",
-    icon: SettingsIcon,
-    keywords: ["webhook", "webhooks", "delivery", "logs", "url", "endpoint"],
-  },
-  {
-    id: "settings",
-    label: "Settings",
-    description: "API keys, webhook URL & merchant config",
-    href: "/settings",
-    icon: SettingsIcon,
-    keywords: ["settings", "config", "api", "keys", "webhook", "merchant"],
-  },
-  {
-    id: "create-payment",
-    label: "Create Payment",
-    description: "Generate a new PLUTO payment link",
-    href: "/dashboard/create",
-    icon: CreatePaymentIcon,
-    keywords: ["create", "payment", "new", "link", "pay", "generate"],
-  },
-  {
-    id: "home",
-    label: "Home",
-    description: "Return to the landing page",
-    href: "/",
-    icon: HomeIcon,
-    keywords: ["home", "landing", "dashboard", "main"],
-  },
-  {
-    id: "register",
-    label: "Register Merchant",
-    description: "Register a new merchant account",
-    href: "/register",
-    icon: RegisterIcon,
-    keywords: ["register", "merchant", "signup", "account", "new"],
-  },
-  {
-    id: "asset-converter",
-    label: "Asset Converter",
-    description: "Look up real-time Stellar conversion rates",
-    action: "converter",
-    icon: (
-      <svg viewBox="0 0 24 24" className="h-5 w-5 text-[#A0A0A0]" fill="none" stroke="currentColor" strokeWidth={1.8}>
-        <path d="M2 17 12 7l10 10" strokeLinecap="round" strokeLinejoin="round" opacity={0.4} />
-        <path d="M2 12 12 2l10 10" strokeLinecap="round" strokeLinejoin="round" />
-      </svg>
-    ),
-    keywords: ["convert", "converter", "rate", "exchange", "swap", "xlm", "usdc", "path", "calculator", "asset"],
-  },
-];
+const HelpIcon = (
+  <svg
+    viewBox="0 0 24 24"
+    className="h-5 w-5 text-[#A0A0A0]"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.8}
+  >
+    <circle cx="12" cy="12" r="9" />
+    <path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.7C13 11.5 12 12 12 13" strokeLinecap="round" />
+    <circle cx="12" cy="17" r="0.6" fill="currentColor" stroke="none" />
+  </svg>
+);
 
-/* ------------------------------------------------------------------ */
-/*  Component                                                          */
-/* ------------------------------------------------------------------ */
+function getCommandIcon(command: PaletteCommand): React.ReactNode {
+  if (command.action === "converter") return ConverterIcon;
+  if (command.action === "copy-api-key") return KeyIcon;
+  if (command.action === "toggle-theme") return ThemeIcon;
+  if (command.id.startsWith("help-")) return HelpIcon;
+  if (command.id.includes("settings") || command.id.includes("webhook") || command.id.includes("api")) {
+    return SettingsIcon;
+  }
+  if (command.id.includes("docs")) return DocsIcon;
+  if (command.id.includes("payment")) return CreatePaymentIcon;
+  return HomeIcon;
+}
 
 export default function CommandPalette() {
   const [open, setOpen] = useState(false);
@@ -166,24 +157,15 @@ export default function CommandPalette() {
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
   const router = useRouter();
+  const apiKey = useMerchantApiKey();
+  const { toggleTheme } = useThemeActions();
+  const { theme, resolvedTheme } = useThemeState();
 
-  /* ---------- filtered results ---------- */
-  const filtered =
-    query.length === 0
-      ? commands
-      : commands.filter((cmd) => {
-          const q = query.toLowerCase();
-          return (
-            cmd.label.toLowerCase().includes(q) ||
-            cmd.description.toLowerCase().includes(q) ||
-            cmd.keywords.some((kw) => kw.includes(q))
-          );
-        });
+  const filtered = useMemo(() => filterPaletteCommands(query), [query]);
 
-  /* ---------- global keydown: Cmd/Ctrl+K ---------- */
   useEffect(() => {
     function handleGlobalKeydown(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
         e.preventDefault();
         setOpen((prev) => !prev);
       }
@@ -193,43 +175,66 @@ export default function CommandPalette() {
     return () => window.removeEventListener("keydown", handleGlobalKeydown);
   }, []);
 
-  /* ---------- focus input when palette opens ---------- */
   useEffect(() => {
     if (open) {
       setQuery("");
       setActiveIndex(0);
       setView("commands");
-      // Small delay so the DOM renders first
       requestAnimationFrame(() => inputRef.current?.focus());
     }
   }, [open]);
 
-  /* ---------- keep activeIndex in bounds ---------- */
   useEffect(() => {
     setActiveIndex(0);
   }, [query]);
 
-  /* ---------- scroll active item into view ---------- */
   useEffect(() => {
-    if (!listRef.current) return;
-    const active = listRef.current.children[activeIndex] as HTMLElement | undefined;
-    active?.scrollIntoView({ block: "nearest" });
-  }, [activeIndex]);
+    if (!listRef.current || filtered.length === 0) return;
+    const activeItem = listRef.current.children[activeIndex] as HTMLElement | undefined;
+    activeItem?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex, filtered.length]);
 
-  /* ---------- select a command ---------- */
   const select = useCallback(
-    (cmd: Command) => {
-      if (cmd.action === "converter") {
+    async (command: PaletteCommand) => {
+      if (command.action === "converter") {
         setView("converter");
         return;
       }
+
       setOpen(false);
-      if (cmd.href) router.push(cmd.href);
+
+      if (command.action === "copy-api-key") {
+        if (!apiKey) {
+          toast.error("No API key is available to copy right now.");
+          return;
+        }
+
+        try {
+          if (typeof navigator === "undefined" || typeof navigator.clipboard?.writeText !== "function") {
+            throw new Error("Clipboard API unavailable");
+          }
+          await navigator.clipboard.writeText(apiKey);
+          toast.success("API key copied to clipboard.");
+        } catch {
+          toast.error("Unable to copy API key from this browser context.");
+        }
+        return;
+      }
+
+      if (command.action === "toggle-theme") {
+        const nextTheme = getNextTheme(theme);
+        toggleTheme();
+        toast.success(`Switched theme to ${getThemeLabel(nextTheme, resolvedTheme)}.`);
+        return;
+      }
+
+      if (command.href) {
+        router.push(command.href);
+      }
     },
-    [router],
+    [apiKey, resolvedTheme, router, theme, toggleTheme],
   );
 
-  /* ---------- palette keydown: arrows, enter, escape ---------- */
   function handlePaletteKeydown(e: React.KeyboardEvent) {
     if (e.key === "Escape") {
       e.preventDefault();
@@ -241,16 +246,17 @@ export default function CommandPalette() {
       return;
     }
 
-    // Block arrow/enter handling when converter is active
     if (view === "converter") return;
 
     if (e.key === "ArrowDown") {
+      if (filtered.length === 0) return;
       e.preventDefault();
       setActiveIndex((i) => (i + 1) % filtered.length);
       return;
     }
 
     if (e.key === "ArrowUp") {
+      if (filtered.length === 0) return;
       e.preventDefault();
       setActiveIndex((i) => (i - 1 + filtered.length) % filtered.length);
       return;
@@ -258,20 +264,18 @@ export default function CommandPalette() {
 
     if (e.key === "Enter" && filtered.length > 0) {
       e.preventDefault();
-      select(filtered[activeIndex]);
+      void select(filtered[activeIndex]);
     }
   }
 
   if (!open) return null;
 
   return (
-    /* backdrop */
     <div
-      className="fixed inset-0 z-[100] flex items-start justify-center bg-black/60 backdrop-blur-sm pt-[15vh]"
+      className="fixed inset-0 z-[100] flex items-start justify-center bg-black/60 pt-[15vh] backdrop-blur-sm"
       onClick={() => setOpen(false)}
       aria-hidden="true"
     >
-      {/* palette card */}
       <div
         role="dialog"
         aria-label="Command palette"
@@ -282,115 +286,99 @@ export default function CommandPalette() {
         {view === "converter" ? (
           <AssetConverter onBack={() => setView("commands")} />
         ) : (
-        <>
-        {/* search input */}
-        <div className="flex items-center gap-3 border-b border-white/10 px-4 py-3">
-          <svg
-            viewBox="0 0 24 24"
-            className="h-5 w-5 shrink-0 text-[#A0A0A0]"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth={2}
-          >
-            <circle cx="11" cy="11" r="7" />
-            <path d="m21 21-4.3-4.3" strokeLinecap="round" />
-          </svg>
-
-          <input
-            ref={inputRef}
-            type="text"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Type a command…"
-            className="flex-1 bg-transparent text-sm font-black text-white font-heading tracking-widest placeholder:text-white/10 outline-none"
-            aria-label="Search commands"
-            aria-activedescendant={
-              filtered.length > 0 ? `cmd-${filtered[activeIndex].id}` : undefined
-            }
-            role="combobox"
-            aria-expanded="true"
-            aria-controls="command-list"
-            aria-autocomplete="list"
-          />
-
-          <kbd className="hidden rounded-lg border border-[#1F1F1F] bg-white/[0.03] px-2 py-1 font-heading text-[10px] font-black text-[#A0A0A0] sm:inline-block">
-            ESC
-          </kbd>
-        </div>
-
-        {/* results list */}
-        <ul
-          id="command-list"
-          ref={listRef}
-          role="listbox"
-          className="max-h-72 overflow-y-auto p-2"
-        >
-          {filtered.length === 0 && (
-            <li className="px-3 py-6 text-center text-sm text-slate-500">
-              No matching commands
-            </li>
-          )}
-
-          {filtered.map((cmd, i) => (
-            <li
-              key={cmd.id}
-              id={`cmd-${cmd.id}`}
-              role="option"
-              aria-selected={i === activeIndex}
-              className={`flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2.5 transition-colors ${
-                i === activeIndex
-                  ? "bg-accent/10 text-white"
-                  : "text-slate-300 hover:bg-white/5"
-              }`}
-              onMouseEnter={() => setActiveIndex(i)}
-              onClick={() => select(cmd)}
-            >
-              <span
-                className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border transition-all ${
-                  i === activeIndex
-                    ? "border-[#00F5D4]/30 bg-[#00F5D4]/10 shadow-[0_0_15px_rgba(0,245,212,0.1)]"
-                    : "border-[#1F1F1F] bg-white/[0.03]"
-                }`}
+          <>
+            <div className="flex items-center gap-3 border-b border-white/10 px-4 py-3">
+              <svg
+                viewBox="0 0 24 24"
+                className="h-5 w-5 shrink-0 text-[#A0A0A0]"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
               >
-                {cmd.icon}
-              </span>
+                <circle cx="11" cy="11" r="7" />
+                <path d="m21 21-4.3-4.3" strokeLinecap="round" />
+              </svg>
 
-              <span className="flex flex-col gap-0.5">
-                <span className="text-sm font-black font-heading tracking-widest uppercase">{cmd.label}</span>
-                <span className="text-[10px] font-medium text-[#A0A0A0] uppercase tracking-wider">{cmd.description}</span>
-              </span>
+              <input
+                ref={inputRef}
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Type a command..."
+                className="flex-1 bg-transparent font-heading text-sm font-black tracking-widest text-white outline-none placeholder:text-white/10"
+                aria-label="Search commands"
+                aria-activedescendant={filtered.length > 0 ? `cmd-${filtered[activeIndex].id}` : undefined}
+                role="combobox"
+                aria-expanded="true"
+                aria-controls="command-list"
+                aria-autocomplete="list"
+              />
 
-              {i === activeIndex && (
-                <kbd className="ml-auto hidden rounded-lg border border-white/10 bg-white/10 px-2 py-1 font-heading text-[10px] font-black text-[#A0A0A0] sm:inline-block">
-                  ENTER
-                </kbd>
+              <kbd className="hidden rounded-lg border border-[#1F1F1F] bg-white/[0.03] px-2 py-1 font-heading text-[10px] font-black text-[#A0A0A0] sm:inline-block">
+                ESC
+              </kbd>
+            </div>
+
+            <ul id="command-list" ref={listRef} role="listbox" className="max-h-72 overflow-y-auto p-2">
+              {filtered.length === 0 && (
+                <li className="px-3 py-6 text-center text-sm text-slate-500">No matching commands</li>
               )}
-            </li>
-          ))}
-        </ul>
 
-        {/* footer hint */}
-        <div className="flex items-center gap-4 border-t border-white/10 px-4 py-2">
-          <span className="flex items-center gap-1 text-[11px] text-slate-500">
-            <kbd className="rounded border border-white/10 bg-white/5 px-1 py-0.5 font-mono text-[10px]">
-              ↑↓
-            </kbd>
-            navigate
-          </span>
-          <span className="flex items-center gap-1 text-[11px] text-slate-500">
-            <kbd className="rounded border border-white/10 bg-white/5 px-1 py-0.5 font-mono text-[10px]">
-              ↵
-            </kbd>
-            select
-          </span>
-          <span className="flex items-center gap-1 text-[11px] text-slate-500">
-            <kbd className="rounded border border-white/10 bg-white/5 px-1 py-0.5 font-mono text-[10px]">
-              esc
-            </kbd>
-            close
-          </span>
-        </div>
-        </>
+              {filtered.map((command, index) => (
+                <li
+                  key={command.id}
+                  id={`cmd-${command.id}`}
+                  role="option"
+                  aria-selected={index === activeIndex}
+                  className={`flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2.5 transition-colors ${
+                    index === activeIndex ? "bg-accent/10 text-white" : "text-slate-300 hover:bg-white/5"
+                  }`}
+                  onMouseEnter={() => setActiveIndex(index)}
+                  onClick={() => {
+                    void select(command);
+                  }}
+                >
+                  <span
+                    className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border transition-all ${
+                      index === activeIndex
+                        ? "border-[#00F5D4]/30 bg-[#00F5D4]/10 shadow-[0_0_15px_rgba(0,245,212,0.1)]"
+                        : "border-[#1F1F1F] bg-white/[0.03]"
+                    }`}
+                  >
+                    {getCommandIcon(command)}
+                  </span>
+
+                  <span className="flex flex-col gap-0.5">
+                    <span className="font-heading text-sm font-black uppercase tracking-widest">{command.label}</span>
+                    <span className="text-[10px] font-medium uppercase tracking-wider text-[#A0A0A0]">
+                      {command.description}
+                    </span>
+                  </span>
+
+                  {index === activeIndex && (
+                    <kbd className="ml-auto hidden rounded-lg border border-white/10 bg-white/10 px-2 py-1 font-heading text-[10px] font-black text-[#A0A0A0] sm:inline-block">
+                      ENTER
+                    </kbd>
+                  )}
+                </li>
+              ))}
+            </ul>
+
+            <div className="flex items-center gap-4 border-t border-white/10 px-4 py-2">
+              <span className="flex items-center gap-1 text-[11px] text-slate-500">
+                <kbd className="rounded border border-white/10 bg-white/5 px-1 py-0.5 font-mono text-[10px]">UP/DOWN</kbd>
+                navigate
+              </span>
+              <span className="flex items-center gap-1 text-[11px] text-slate-500">
+                <kbd className="rounded border border-white/10 bg-white/5 px-1 py-0.5 font-mono text-[10px]">ENTER</kbd>
+                select
+              </span>
+              <span className="flex items-center gap-1 text-[11px] text-slate-500">
+                <kbd className="rounded border border-white/10 bg-white/5 px-1 py-0.5 font-mono text-[10px]">ESC</kbd>
+                close
+              </span>
+            </div>
+          </>
         )}
       </div>
     </div>

--- a/frontend/src/components/commandPaletteData.ts
+++ b/frontend/src/components/commandPaletteData.ts
@@ -1,0 +1,196 @@
+export type PaletteAction = "converter" | "copy-api-key" | "toggle-theme";
+
+export interface PaletteCommand {
+  id: string;
+  label: string;
+  description: string;
+  href?: string;
+  action?: PaletteAction;
+  keywords: string[];
+}
+
+export const paletteCommands: PaletteCommand[] = [
+  {
+    id: "dashboard",
+    label: "Dashboard",
+    description: "View payments, metrics and activity",
+    href: "/dashboard",
+    keywords: ["dashboard", "home", "overview", "payments", "activity"],
+  },
+  {
+    id: "settings",
+    label: "Settings",
+    description: "Manage merchant profile, branding and webhooks",
+    href: "/settings",
+    keywords: ["settings", "config", "merchant", "profile", "webhooks"],
+  },
+  {
+    id: "docs",
+    label: "Docs",
+    description: "Browse integration guides and help topics",
+    href: "/docs",
+    keywords: ["docs", "documentation", "help", "guides", "tutorials"],
+  },
+  {
+    id: "create-new-payment",
+    label: "Create New Payment",
+    description: "Generate a new payment link",
+    href: "/dashboard/create",
+    keywords: ["create", "payment", "new", "link", "pay", "invoice"],
+  },
+  {
+    id: "copy-api-key",
+    label: "Copy API Key",
+    description: "Copy the current merchant API key to clipboard",
+    action: "copy-api-key",
+    keywords: ["copy", "api", "key", "token", "clipboard", "secret"],
+  },
+  {
+    id: "toggle-theme",
+    label: "Toggle Theme",
+    description: "Cycle between light, dark and system modes",
+    action: "toggle-theme",
+    keywords: ["toggle", "theme", "appearance", "dark", "light", "system"],
+  },
+  {
+    id: "api-keys",
+    label: "API Keys",
+    description: "Open API key management settings",
+    href: "/settings#api-keys",
+    keywords: ["api", "keys", "rotate", "secret", "token"],
+  },
+  {
+    id: "webhooks",
+    label: "Webhooks",
+    description: "Configure webhook URL and inspect delivery logs",
+    href: "/settings#webhooks",
+    keywords: ["webhook", "webhooks", "delivery", "logs", "endpoint"],
+  },
+  {
+    id: "payment-history",
+    label: "Payment History",
+    description: "Review recent and historical payment records",
+    href: "/payment-history",
+    keywords: ["history", "payments", "transactions", "records", "list"],
+  },
+  {
+    id: "help-api-guide",
+    label: "Help: Subscription API Guide",
+    description: "Merchant integration guide for API key workflows",
+    href: "/docs/api-guide",
+    keywords: ["help", "docs", "api", "guide", "subscription", "integration"],
+  },
+  {
+    id: "help-hmac-signatures",
+    label: "Help: Verify HMAC Signatures",
+    description: "Validate webhook signatures correctly",
+    href: "/docs/hmac-signatures",
+    keywords: ["help", "docs", "hmac", "signatures", "webhook", "security"],
+  },
+  {
+    id: "help-x402-agentic-payments",
+    label: "Help: x402 Agentic Payments",
+    description: "Set up pay-per-request pricing for agents",
+    href: "/docs/x402-agentic-payments",
+    keywords: ["help", "docs", "x402", "agentic", "payments", "pricing"],
+  },
+  {
+    id: "asset-converter",
+    label: "Asset Converter",
+    description: "Look up Stellar conversion rates quickly",
+    action: "converter",
+    keywords: ["convert", "converter", "rates", "exchange", "xlm", "usdc", "asset"],
+  },
+];
+
+function normalize(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function singleFieldScore(target: string, token: string): number {
+  if (!target || !token) return 0;
+
+  const exactIndex = target.indexOf(token);
+  if (exactIndex >= 0) {
+    const startsAtWord = exactIndex === 0 || " -_/".includes(target[exactIndex - 1]);
+    const exactBonus = startsAtWord ? 4 : 2;
+    return exactBonus + token.length / Math.max(target.length, 1);
+  }
+
+  let searchIndex = 0;
+  let previousIndex = -2;
+  let score = 0;
+
+  for (const character of token) {
+    const foundIndex = target.indexOf(character, searchIndex);
+    if (foundIndex === -1) return 0;
+
+    score += 1;
+    if (foundIndex === 0 || " -_/".includes(target[foundIndex - 1])) {
+      score += 0.7;
+    }
+    if (foundIndex === previousIndex + 1) {
+      score += 0.6;
+    }
+
+    previousIndex = foundIndex;
+    searchIndex = foundIndex + 1;
+  }
+
+  return score / (target.length + 1);
+}
+
+function commandScore(command: PaletteCommand, normalizedQuery: string): number {
+  if (!normalizedQuery) return 0;
+
+  const tokens = normalizedQuery.split(/\s+/).filter(Boolean);
+  const fields = [
+    { value: command.label, weight: 3 },
+    { value: command.description, weight: 1.8 },
+    ...command.keywords.map((keyword) => ({ value: keyword, weight: 2.3 })),
+  ];
+
+  let score = 0;
+
+  for (const token of tokens) {
+    let bestTokenScore = 0;
+
+    for (const field of fields) {
+      const fieldValue = normalize(field.value);
+      const fieldScore = singleFieldScore(fieldValue, token) * field.weight;
+      if (fieldScore > bestTokenScore) {
+        bestTokenScore = fieldScore;
+      }
+    }
+
+    if (bestTokenScore <= 0) return 0;
+    score += bestTokenScore;
+  }
+
+  const normalizedLabel = normalize(command.label);
+  if (normalizedLabel === normalizedQuery) {
+    score += 15;
+  } else if (normalizedLabel.startsWith(normalizedQuery)) {
+    score += 6;
+  }
+
+  return score;
+}
+
+export function filterPaletteCommands(
+  query: string,
+  commands: PaletteCommand[] = paletteCommands,
+): PaletteCommand[] {
+  const normalizedQuery = normalize(query);
+  if (!normalizedQuery) return [...commands];
+
+  return commands
+    .map((command) => ({
+      command,
+      score: commandScore(command, normalizedQuery),
+    }))
+    .filter((entry) => entry.score > 0)
+    .sort((left, right) => right.score - left.score || left.command.label.localeCompare(right.command.label))
+    .map((entry) => entry.command);
+}
+


### PR DESCRIPTION
Closes #518

## Summary
Enhances the global command palette so users can quickly navigate and run common actions from anywhere in the app.

## Changes
- Added a dedicated command data/search module:
  - `frontend/src/components/commandPaletteData.ts`
- Added required quick actions:
  - `Create New Payment`
  - `Copy API Key` (uses merchant store + clipboard API)
  - `Toggle Theme` (uses existing theme context)
- Added high-level route navigation commands:
  -
