### PR TITLE
backend: harden asset issuer handling

### DIFF
--- a/backend/src/constants/assetConstants.js
+++ b/backend/src/constants/assetConstants.js
@@ -5,6 +5,36 @@ export const ASSET_DEFAULTS = {
   }
 };
 
+function normalizeAssetCode(assetCode) {
+  return String(assetCode || "").trim().toUpperCase();
+}
+
+export function getDefaultAssetIssuer(assetCode, network = process.env.STELLAR_NETWORK || "testnet") {
+  const asset = normalizeAssetCode(assetCode);
+  const networkKey = String(network || "testnet").trim().toLowerCase();
+  const defaults = ASSET_DEFAULTS[asset];
+
+  if (!defaults) {
+    return null;
+  }
+
+  return defaults[networkKey] || defaults.testnet || null;
+}
+
+export function resolveAssetIssuer(assetCode, assetIssuer, network = process.env.STELLAR_NETWORK || "testnet") {
+  const asset = normalizeAssetCode(assetCode);
+
+  if (asset === "XLM") {
+    return null;
+  }
+
+  if (typeof assetIssuer === "string" && assetIssuer.trim().length > 0) {
+    return assetIssuer.trim();
+  }
+
+  return getDefaultAssetIssuer(asset, network);
+}
+
 export function getPossibleAssets() {
   return Object.keys(ASSET_DEFAULTS);
 }

--- a/backend/src/lib/request-schemas.js
+++ b/backend/src/lib/request-schemas.js
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { HEX_COLOR_REGEX } from "./branding.js";
-import { validateMemo } from "./stellar.js";
+import { resolveAssetIssuer } from "../constants/assetConstants.js";
+import { isValidStellarPublicKey, validateMemo } from "./stellar.js";
 
 const VALID_MEMO_TYPES = ["text", "id", "hash", "return"];
 export const MINIMUM_XLM_PAYMENT_AMOUNT = 0.01;
@@ -95,11 +96,25 @@ function applyPaymentValidationRules(body, ctx) {
     });
   }
 
-  if (body.asset !== "XLM" && !body.asset_issuer) {
+  const resolvedAssetIssuer = resolveAssetIssuer(body.asset, body.asset_issuer);
+
+  if (body.asset !== "XLM" && !resolvedAssetIssuer) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path: ["asset_issuer"],
       message: "asset_issuer is required for non-native assets",
+    });
+  }
+
+  if (
+    body.asset !== "XLM" &&
+    resolvedAssetIssuer &&
+    !isValidStellarPublicKey(resolvedAssetIssuer)
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["asset_issuer"],
+      message: "asset_issuer must be a valid Stellar public key",
     });
   }
 
@@ -140,9 +155,18 @@ function applyPaymentValidationRules(body, ctx) {
   }
 }
 
+function applyResolvedAssetIssuer(body) {
+  const resolvedAssetIssuer = resolveAssetIssuer(body.asset, body.asset_issuer);
+
+  return {
+    ...body,
+    asset_issuer: resolvedAssetIssuer || undefined,
+  };
+}
+
 export const paymentZodSchema = paymentBaseSchema.superRefine(
   applyPaymentValidationRules,
-);
+).transform(applyResolvedAssetIssuer);
 
 export const registerMerchantZodSchema = z.object({
   email: z
@@ -217,7 +241,8 @@ export const paymentSessionZodSchema = paymentBaseSchema
   .extend({
     branding_overrides: sessionBrandingSchema,
   })
-  .superRefine(applyPaymentValidationRules);
+  .superRefine(applyPaymentValidationRules)
+  .transform(applyResolvedAssetIssuer);
 
 export const v2PaymentSessionSchema = paymentSessionZodSchema;
 

--- a/backend/src/lib/request-schemas.test.js
+++ b/backend/src/lib/request-schemas.test.js
@@ -9,12 +9,14 @@ import {
   v2PaymentSessionSchema,
 } from "./request-schemas.js";
 
+const USDC_TESTNET_ISSUER = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+
 describe("paymentZodSchema", () => {
   it("parses and normalizes a valid create-payment request", () => {
     const result = paymentZodSchema.parse({
       amount: "42.5",
       asset: "usdc",
-      asset_issuer: " GISSUER ",
+      asset_issuer: ` ${USDC_TESTNET_ISSUER} `,
       recipient: " GRECIPIENT ",
       client_id: " store-01 ",
       memo: " Order-123 ",
@@ -26,7 +28,7 @@ describe("paymentZodSchema", () => {
     expect(result).toEqual({
       amount: 42.5,
       asset: "USDC",
-      asset_issuer: "GISSUER",
+      asset_issuer: USDC_TESTNET_ISSUER,
       recipient: "GRECIPIENT",
       client_id: "store-01",
       description: undefined,
@@ -37,14 +39,46 @@ describe("paymentZodSchema", () => {
     });
   });
 
-  it("requires asset_issuer for non-native assets", () => {
+  it("recovers the default issuer for configured non-native assets", () => {
+    const result = paymentZodSchema.parse({
+      amount: 50,
+      asset: "USDC",
+      recipient: "GRECIPIENT",
+    });
+
+    expect(result.asset_issuer).toBe(USDC_TESTNET_ISSUER);
+  });
+
+  it("requires asset_issuer for non-native assets without configured defaults", () => {
     expect(() =>
       paymentZodSchema.parse({
         amount: 50,
-        asset: "USDC",
+        asset: "EURC",
         recipient: "GRECIPIENT",
       })
     ).toThrowError("asset_issuer is required for non-native assets");
+  });
+
+  it("rejects invalid asset_issuer public keys", () => {
+    expect(() =>
+      paymentZodSchema.parse({
+        amount: 50,
+        asset: "EURC",
+        asset_issuer: "issuer-1",
+        recipient: "GRECIPIENT",
+      })
+    ).toThrowError("asset_issuer must be a valid Stellar public key");
+  });
+
+  it("ignores asset_issuer for native XLM payments", () => {
+    const result = paymentZodSchema.parse({
+      amount: 50,
+      asset: "XLM",
+      asset_issuer: USDC_TESTNET_ISSUER,
+      recipient: "GRECIPIENT",
+    });
+
+    expect(result.asset_issuer).toBeUndefined();
   });
 
   it("requires memo_type when memo is provided", () => {
@@ -202,8 +236,8 @@ describe("paymentZodSchema", () => {
   it("does not apply the XLM minimum to non-native assets", () => {
     const result = paymentZodSchema.parse({
       amount: 0.0000001,
-      asset: "USDC",
-      asset_issuer: "GISSUER",
+      asset: "EURC",
+      asset_issuer: USDC_TESTNET_ISSUER,
       recipient: "GRECIPIENT",
     });
 

--- a/backend/src/lib/stellar.js
+++ b/backend/src/lib/stellar.js
@@ -11,6 +11,8 @@ const HORIZON_URL = (
 
 const server = new StellarSdk.Horizon.Server(HORIZON_URL);
 const HORIZON_HEALTH_TIMEOUT_MS = 2_000;
+const STELLAR_PUBLIC_KEY_PATTERN = /^G[A-Z2-7]{55}$/;
+const ASSET_CODE_PATTERN = /^[A-Z0-9]{1,12}$/;
 
 function parseStroops(value) {
   const parsed = Number.parseInt(String(value ?? ""), 10);
@@ -136,11 +138,17 @@ export async function isHorizonReachable() {
 }
 
 export function resolveAsset(assetCode, assetIssuer) {
-  if (!assetCode) {
+  const normalizedAssetCode = String(assetCode || "").trim().toUpperCase();
+
+  if (!normalizedAssetCode) {
     throw new Error("Asset code is required");
   }
 
-  if (assetCode.toUpperCase() === "XLM") {
+  if (!ASSET_CODE_PATTERN.test(normalizedAssetCode)) {
+    throw new Error("Asset code must be 1-12 alphanumeric characters");
+  }
+
+  if (normalizedAssetCode === "XLM") {
     return StellarSdk.Asset.native();
   }
 
@@ -148,7 +156,36 @@ export function resolveAsset(assetCode, assetIssuer) {
     throw new Error("Asset issuer is required for non-native assets");
   }
 
-  return new StellarSdk.Asset(assetCode.toUpperCase(), assetIssuer);
+  const normalizedAssetIssuer = String(assetIssuer).trim();
+
+  if (!isValidStellarPublicKey(normalizedAssetIssuer)) {
+    throw new Error("Asset issuer must be a valid Stellar public key");
+  }
+
+  return new StellarSdk.Asset(normalizedAssetCode, normalizedAssetIssuer);
+}
+
+export function isValidStellarPublicKey(value) {
+  const publicKey = String(value || "").trim();
+
+  if (!STELLAR_PUBLIC_KEY_PATTERN.test(publicKey)) {
+    return false;
+  }
+
+  if (typeof StellarSdk.StrKey?.isValidEd25519PublicKey === "function") {
+    return StellarSdk.StrKey.isValidEd25519PublicKey(publicKey);
+  }
+
+  if (typeof StellarSdk.Keypair?.fromPublicKey === "function") {
+    try {
+      StellarSdk.Keypair.fromPublicKey(publicKey);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 function amountsMatch(expected, received) {

--- a/backend/src/routes/metadata-filter.test.js
+++ b/backend/src/routes/metadata-filter.test.js
@@ -59,8 +59,12 @@ vi.mock("../lib/webhooks.js", () => ({
 }));
 vi.mock("../lib/stellar.js", () => ({
   findMatchingPayment: vi.fn(),
+  findAnyRecentPayment: vi.fn(),
   findStrictReceivePaths: vi.fn(),
   getNetworkFeeStats: vi.fn(),
+  isValidStellarPublicKey: vi.fn(() => true),
+  validateMemo: vi.fn(() => ({ valid: true })),
+  verifyTransactionSignature: vi.fn(),
 }));
 vi.mock("../lib/pagination-links.js", () => ({
   generatePaginationLinks: vi.fn().mockReturnValue({}),

--- a/backend/src/routes/payments-path-quote.test.js
+++ b/backend/src/routes/payments-path-quote.test.js
@@ -9,7 +9,12 @@ const { findStrictReceivePaths, supabaseFrom } = vi.hoisted(() => ({
 vi.mock("../lib/stellar.js", () => ({
     findStrictReceivePaths,
     findMatchingPayment: vi.fn(),
+    findAnyRecentPayment: vi.fn(),
     createRefundTransaction: vi.fn(),
+    getNetworkFeeStats: vi.fn(),
+    isValidStellarPublicKey: vi.fn(() => true),
+    validateMemo: vi.fn(() => ({ valid: true })),
+    verifyTransactionSignature: vi.fn(),
 }));
 
 vi.mock("../lib/supabase.js", () => ({

--- a/backend/src/routes/payments-pooler.test.js
+++ b/backend/src/routes/payments-pooler.test.js
@@ -33,6 +33,8 @@ vi.mock("../lib/stellar.js", () => ({
   findAnyRecentPayment: mockFindAnyRecentPayment,
   findStrictReceivePaths: vi.fn(),
   getNetworkFeeStats: vi.fn(),
+  isValidStellarPublicKey: vi.fn(() => true),
+  validateMemo: vi.fn(() => ({ valid: true })),
   verifyTransactionSignature: mockVerifyTransactionSignature,
 }));
 

--- a/backend/src/routes/payments-security.test.js
+++ b/backend/src/routes/payments-security.test.js
@@ -21,8 +21,13 @@ vi.mock('../lib/supabase.js', () => ({
 
 vi.mock('../lib/stellar.js', () => ({
     findMatchingPayment: vi.fn(),
+    findAnyRecentPayment: vi.fn(),
     findStrictReceivePaths: vi.fn(),
     createRefundTransaction: vi.fn(),
+    getNetworkFeeStats: vi.fn(),
+    isValidStellarPublicKey: vi.fn(() => true),
+    validateMemo: vi.fn(() => ({ valid: true })),
+    verifyTransactionSignature: vi.fn(),
 }));
 
 vi.mock('../lib/redis.js', () => ({

--- a/backend/src/routes/payments.js
+++ b/backend/src/routes/payments.js
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { logger } from "../lib/logger.js";
 import express from "express";
 import { paymentService } from "../services/paymentService.js";
+import { resolveAssetIssuer } from "../constants/assetConstants.js";
 import { validateUuidParam } from "../lib/validate-uuid.js";
 import {
   paymentSessionZodSchema,
@@ -41,6 +42,7 @@ import {
   findAnyRecentPayment,
   findStrictReceivePaths,
   getNetworkFeeStats,
+  isValidStellarPublicKey,
   verifyTransactionSignature,
 } from "../lib/stellar.js";
 
@@ -236,7 +238,23 @@ function createPaymentsRouter({
     try {
       const supabase = await getSupabaseClient();
       const body = req.body;
+      const asset = body.asset?.toUpperCase();
+      const assetIssuer = resolveAssetIssuer(asset, body.asset_issuer);
       logger.info({ merchantId: req.merchant?.id, amount: body.amount, asset: body.asset }, "DEBUG: createSession started");
+
+      if (asset !== "XLM" && !assetIssuer) {
+        paymentFailedCounter.inc({ asset: body.asset, reason: "missing_issuer" });
+        return res.status(400).json({
+          error: "asset_issuer is required for non-native assets",
+        });
+      }
+
+      if (asset !== "XLM" && !isValidStellarPublicKey(assetIssuer)) {
+        paymentFailedCounter.inc({ asset: body.asset, reason: "invalid_issuer" });
+        return res.status(400).json({
+          error: "asset_issuer must be a valid Stellar public key",
+        });
+      }
 
       // Per-asset payment limit validation (#153)
       const limits = req.merchant.payment_limits;
@@ -265,8 +283,8 @@ function createPaymentsRouter({
       // Allowed-issuers check: if the merchant has configured a non-empty
       // allowlist, only those issuer addresses may be used.
       const allowedIssuers = req.merchant.allowed_issuers;
-      if (Array.isArray(allowedIssuers) && allowedIssuers.length > 0) {
-        if (!body.asset_issuer || !allowedIssuers.includes(body.asset_issuer)) {
+      if (asset !== "XLM" && Array.isArray(allowedIssuers) && allowedIssuers.length > 0) {
+        if (!assetIssuer || !allowedIssuers.includes(assetIssuer)) {
           paymentFailedCounter.inc({ asset: body.asset, reason: "invalid_issuer" });
           return res.status(400).json({
             error:
@@ -297,8 +315,8 @@ function createPaymentsRouter({
         id: paymentId,
         merchant_id: req.merchant.id,
         amount: body.amount,
-        asset: body.asset,
-        asset_issuer: body.asset_issuer || null,
+        asset,
+        asset_issuer: assetIssuer || null,
         recipient: body.recipient,
         description: body.description || null,
         memo: body.message || body.memo || null,

--- a/backend/src/routes/sandbox.test.js
+++ b/backend/src/routes/sandbox.test.js
@@ -55,8 +55,12 @@ vi.mock("../lib/webhooks.js", () => ({
 }));
 vi.mock("../lib/stellar.js", () => ({
   findMatchingPayment: vi.fn(),
+  findAnyRecentPayment: vi.fn(),
   findStrictReceivePaths: vi.fn(),
   getNetworkFeeStats: vi.fn(),
+  isValidStellarPublicKey: vi.fn(() => true),
+  validateMemo: vi.fn(() => ({ valid: true })),
+  verifyTransactionSignature: vi.fn(),
 }));
 vi.mock("../lib/pagination-links.js", () => ({
   generatePaginationLinks: vi.fn().mockReturnValue({}),

--- a/backend/src/services/paymentService.js
+++ b/backend/src/services/paymentService.js
@@ -4,6 +4,7 @@ import {
   findMatchingPayment,
   createRefundTransaction,
   findStrictReceivePaths,
+  isValidStellarPublicKey,
   verifyTransactionSignature,
 } from "../lib/stellar.js";
 import { resolveBrandingConfig } from "../lib/branding.js";
@@ -17,7 +18,7 @@ import {
   setCachedPayment,
   invalidatePaymentCache,
 } from "../lib/redis.js";
-import { ASSET_DEFAULTS } from "../constants/assetConstants.js";
+import { resolveAssetIssuer } from "../constants/assetConstants.js";
 import {
   paymentCreatedCounter,
   paymentConfirmedCounter,
@@ -458,6 +459,21 @@ async function getRollingMetricsViaSupabase(merchantId) {
 export const paymentService = {
   async createPaymentSession(merchant, body) {
     const supabase = await getSupabaseClient();
+    const asset = body.asset?.toUpperCase();
+    const assetIssuer = resolveAssetIssuer(asset, body.asset_issuer);
+
+    if (asset !== "XLM" && !assetIssuer) {
+      const error = new Error("asset_issuer is required for non-native assets");
+      error.status = 400;
+      throw error;
+    }
+
+    if (asset !== "XLM" && !isValidStellarPublicKey(assetIssuer)) {
+      const error = new Error("asset_issuer must be a valid Stellar public key");
+      error.status = 400;
+      throw error;
+    }
+
     // Per-asset payment limit validation
     const limits = merchant.payment_limits;
     if (limits && typeof limits === "object") {
@@ -488,8 +504,8 @@ export const paymentService = {
 
     // Allowed-issuers check
     const allowedIssuers = merchant.allowed_issuers;
-    if (Array.isArray(allowedIssuers) && allowedIssuers.length > 0) {
-      if (!body.asset_issuer || !allowedIssuers.includes(body.asset_issuer)) {
+    if (asset !== "XLM" && Array.isArray(allowedIssuers) && allowedIssuers.length > 0) {
+      if (!assetIssuer || !allowedIssuers.includes(assetIssuer)) {
         paymentFailedCounter.inc({ asset: body.asset, reason: "invalid_issuer" });
         const error = new Error("asset_issuer is not in the merchant's list of allowed issuers");
         error.status = 400;
@@ -511,19 +527,14 @@ export const paymentService = {
     metadata.branding_config = resolvedBranding;
 
     const network = (process.env.STELLAR_NETWORK || "testnet").toLowerCase();
-    const asset = body.asset?.toUpperCase();
-    let assetIssuer = body.asset_issuer;
-
-    if (!assetIssuer && ASSET_DEFAULTS[asset]) {
-      assetIssuer = ASSET_DEFAULTS[asset][network] || ASSET_DEFAULTS[asset]["testnet"];
-    }
+    const resolvedAssetIssuer = resolveAssetIssuer(asset, assetIssuer, network);
 
     const payload = {
       id: paymentId,
       merchant_id: merchant.id,
       amount: body.amount,
       asset: asset,
-      asset_issuer: assetIssuer || null,
+      asset_issuer: resolvedAssetIssuer || null,
       recipient: body.recipient,
       description: body.description || null,
       memo: body.memo || null,

--- a/backend/src/services/paymentService.test.js
+++ b/backend/src/services/paymentService.test.js
@@ -5,6 +5,7 @@ const {
   mockIsRetryablePoolError,
   mockSupabaseFrom,
   mockFindMatchingPayment,
+  mockIsValidStellarPublicKey,
   mockVerifyTransactionSignature,
   mockConnectRedisClient,
   mockGetCachedPayment,
@@ -20,6 +21,7 @@ const {
   mockIsRetryablePoolError: vi.fn(),
   mockSupabaseFrom: vi.fn(),
   mockFindMatchingPayment: vi.fn(),
+  mockIsValidStellarPublicKey: vi.fn(),
   mockVerifyTransactionSignature: vi.fn(),
   mockConnectRedisClient: vi.fn(),
   mockGetCachedPayment: vi.fn(),
@@ -47,6 +49,7 @@ vi.mock("../lib/stellar.js", () => ({
   findMatchingPayment: mockFindMatchingPayment,
   createRefundTransaction: vi.fn(),
   findStrictReceivePaths: vi.fn(),
+  isValidStellarPublicKey: mockIsValidStellarPublicKey,
   verifyTransactionSignature: mockVerifyTransactionSignature,
 }));
 
@@ -86,9 +89,12 @@ vi.mock("../lib/metrics.js", () => ({
 
 import { paymentService } from "./paymentService.js";
 
+const USDC_TESTNET_ISSUER = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+
 describe("paymentService", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsValidStellarPublicKey.mockReturnValue(true);
     mockResolveBrandingConfig.mockReturnValue({ primary_color: "#000000" });
     mockConnectRedisClient.mockResolvedValue({ isOpen: false });
     mockGetCachedPayment.mockResolvedValue(null);
@@ -162,6 +168,39 @@ describe("paymentService", () => {
       page: 1,
       limit: 20,
     });
+  });
+
+  it("resolves default asset issuers before allowlist checks and inserts", async () => {
+    const insert = vi.fn().mockResolvedValue({ error: null });
+    mockSupabaseFrom.mockReturnValue({ insert });
+
+    const result = await paymentService.createPaymentSession(
+      {
+        id: "merchant-1",
+        allowed_issuers: [USDC_TESTNET_ISSUER],
+        payment_limits: {},
+        branding_config: {},
+      },
+      {
+        amount: 12.5,
+        asset: "USDC",
+        recipient: "GRECIPIENT",
+      },
+    );
+
+    expect(result).toMatchObject({
+      status: "pending",
+      branding_config: { primary_color: "#000000" },
+    });
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        merchant_id: "merchant-1",
+        amount: 12.5,
+        asset: "USDC",
+        asset_issuer: USDC_TESTNET_ISSUER,
+        recipient: "GRECIPIENT",
+      }),
+    );
   });
 
   it("falls back to Supabase when the pooler exhausts retryable errors", async () => {

--- a/backend/tests/integration/health.test.js
+++ b/backend/tests/integration/health.test.js
@@ -15,7 +15,14 @@ const mockRedisClient = {
 };
 
 vi.mock("../../src/lib/stellar.js", () => ({
+  findMatchingPayment: vi.fn(),
+  findAnyRecentPayment: vi.fn(),
+  findStrictReceivePaths: vi.fn(),
+  getNetworkFeeStats: vi.fn(),
   isHorizonReachable: vi.fn(async () => true),
+  isValidStellarPublicKey: vi.fn(() => true),
+  validateMemo: vi.fn(() => ({ valid: true })),
+  verifyTransactionSignature: vi.fn(),
 }));
 
 vi.mock("../../src/lib/supabase.js", () => {

--- a/backend/tests/integration/payments.test.js
+++ b/backend/tests/integration/payments.test.js
@@ -248,6 +248,7 @@ vi.mock("../../src/lib/stellar.js", () => ({
   verifyTransactionSignature: (...args) => mockVerifyTransactionSignature(...args),
   getNetworkFeeStats: (...args) => mockGetNetworkFeeStats(...args),
   isHorizonReachable: vi.fn(async () => true),
+  isValidStellarPublicKey: vi.fn(() => true),
   resolveAsset: vi.fn(),
   createRefundTransaction: vi.fn(),
   findStrictReceivePaths: vi.fn(),


### PR DESCRIPTION
Closes #607
Closes #608
Closes #606
Closes #609

## Changes
- Resolve configured default issuers for standard non-native assets like USDC before allowlist checks and inserts.
- Validate `asset_issuer` values as Stellar public keys in schema, route, service, and Stellar asset resolution paths.
- Keep native XLM issuerless so issuer allowlists only apply to non-native assets.
- Update focused schema/service tests and route test mocks for the new issuer validation helper.

## Testing
- `git diff --check`
- `node --check backend/src/lib/request-schemas.js`
- `node --check backend/src/services/paymentService.js`
- `node --check backend/src/routes/payments.js`
- `node --check backend/src/lib/stellar.js`
- `node --check backend/src/constants/assetConstants.js`
- `node --check backend/src/lib/request-schemas.test.js`
- `node --check backend/src/services/paymentService.test.js`

Full test suite not run; dependencies were not installed per request.