### PR TITLE
feat(frontend): balance-sync tests + optimistic updates, SR live region, onboarding reducer extraction

### DIFF
--- a/frontend/src/components/OnboardingProgressTracker.tsx
+++ b/frontend/src/components/OnboardingProgressTracker.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback, useMemo, useEffect, useReducer, useRef } from "react";
 import { motion, AnimatePresence, useReducedMotion, type Variants } from "framer-motion";
 import { useTranslations } from "next-intl";
+import { onboardingReducer, createInitialOnboardingState } from "./onboarding-reducer";
 
 /**
  * Step interface for onboarding progress
@@ -27,48 +28,6 @@ interface OnboardingProgressTrackerProps {
   showStepNumbers?: boolean;
   orientation?: "vertical" | "horizontal";
   compact?: boolean;
-}
-
-/**
- * State for onboarding tracker — supports optimistic updates with rollback
- */
-interface OnboardingState {
-  currentStep: string | undefined;
-  /** Optimistic step id set immediately on click before server confirms */
-  optimisticStep: string | undefined;
-  announcementText: string;
-  /** Whether an optimistic update is pending server confirmation */
-  isPending: boolean;
-}
-
-/**
- * Actions for onboarding state
- */
-type OnboardingAction =
-  | { type: "SET_CURRENT_STEP"; payload: string }
-  | { type: "OPTIMISTIC_STEP"; payload: string }
-  | { type: "CONFIRM_STEP"; payload: string }
-  | { type: "ROLLBACK_STEP" }
-  | { type: "SET_ANNOUNCEMENT"; payload: string };
-
-/**
- * Reducer for onboarding state — handles optimistic updates and rollback
- */
-function onboardingReducer(state: OnboardingState, action: OnboardingAction): OnboardingState {
-  switch (action.type) {
-    case "SET_CURRENT_STEP":
-      return { ...state, currentStep: action.payload, optimisticStep: undefined, isPending: false };
-    case "OPTIMISTIC_STEP":
-      return { ...state, optimisticStep: action.payload, isPending: true };
-    case "CONFIRM_STEP":
-      return { ...state, currentStep: action.payload, optimisticStep: undefined, isPending: false };
-    case "ROLLBACK_STEP":
-      return { ...state, optimisticStep: undefined, isPending: false };
-    case "SET_ANNOUNCEMENT":
-      return { ...state, announcementText: action.payload };
-    default:
-      return state;
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -198,12 +157,10 @@ export const OnboardingProgressTracker: React.FC<OnboardingProgressTrackerProps>
   // Respect user's OS-level "reduce motion" preference — #809
   const prefersReducedMotion = useReducedMotion();
 
-  const [state, dispatch] = useReducer(onboardingReducer, {
-    currentStep: currentStepProp || steps[0]?.id,
-    optimisticStep: undefined,
-    announcementText: "",
-    isPending: false,
-  });
+  const [state, dispatch] = useReducer(
+    onboardingReducer,
+    createInitialOnboardingState(currentStepProp || steps[0]?.id),
+  );
 
   // Track previous step for rollback — #812
   const previousStepRef = useRef<string | undefined>(state.currentStep);

--- a/frontend/src/components/SupportPanel.tsx
+++ b/frontend/src/components/SupportPanel.tsx
@@ -38,7 +38,17 @@ export function SupportPanel() {
 
   const selectedBalance = (balances as any).find((b: any) => b.code === assetCode)?.balance ?? "0";
   const isUnfunded = visitorAddress && balances.length === 0 && !loadingBalance;
-  
+
+  // Single authoritative screen-reader announcement for real-time balance sync,
+  // so updates are spoken as one clear message instead of raw visual swaps.
+  const balanceAnnouncement = !visitorAddress
+    ? ""
+    : loadingBalance
+      ? "Syncing wallet balance…"
+      : isUnfunded
+        ? "Wallet is unfunded."
+        : `Balance synced: ${selectedBalance} ${assetCode}.`;
+
   const handleAmountChange = (val: string) => {
     setAmount(val);
   };
@@ -94,6 +104,11 @@ export function SupportPanel() {
 
   return (
     <div className="flex flex-col gap-5 p-1">
+      {/* Authoritative live region for real-time balance-sync announcements */}
+      <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+        {balanceAnnouncement}
+      </div>
+
       <div className="space-y-4">
         {/* Wallet Info */}
         <div className="flex items-center justify-between text-[11px] font-mono uppercase tracking-wider">
@@ -109,7 +124,8 @@ export function SupportPanel() {
         <div className="space-y-1.5">
           <div className="flex justify-between items-end">
             <label className="text-xs font-semibold text-white" htmlFor="amount-input">Amount</label>
-            <div className="text-[10px] text-slate-400" aria-live="polite" aria-atomic="true">
+            {/* Visual-only — announcements are handled by the live region above. */}
+            <div className="text-[10px] text-slate-400">
               {loadingBalance ? (
                 <div className="flex items-center gap-2">
                   <span className="sr-only">Loading balance...</span>

--- a/frontend/src/components/onboarding-reducer.test.ts
+++ b/frontend/src/components/onboarding-reducer.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import {
+  createInitialOnboardingState,
+  onboardingReducer,
+  type OnboardingState,
+} from "./onboarding-reducer";
+
+describe("onboardingReducer", () => {
+  const base: OnboardingState = createInitialOnboardingState("step-1");
+
+  it("creates initial state from a starting step", () => {
+    expect(createInitialOnboardingState("step-1")).toEqual({
+      currentStep: "step-1",
+      optimisticStep: undefined,
+      announcementText: "",
+      isPending: false,
+    });
+  });
+
+  it("marks an optimistic step as pending without changing the current step", () => {
+    const next = onboardingReducer(base, { type: "OPTIMISTIC_STEP", payload: "step-2" });
+    expect(next.optimisticStep).toBe("step-2");
+    expect(next.isPending).toBe(true);
+    expect(next.currentStep).toBe("step-1");
+  });
+
+  it("confirms an optimistic step", () => {
+    const pending = onboardingReducer(base, { type: "OPTIMISTIC_STEP", payload: "step-2" });
+    const next = onboardingReducer(pending, { type: "CONFIRM_STEP", payload: "step-2" });
+    expect(next.currentStep).toBe("step-2");
+    expect(next.optimisticStep).toBeUndefined();
+    expect(next.isPending).toBe(false);
+  });
+
+  it("rolls back an optimistic step, keeping the confirmed current step", () => {
+    const pending = onboardingReducer(base, { type: "OPTIMISTIC_STEP", payload: "step-2" });
+    const next = onboardingReducer(pending, { type: "ROLLBACK_STEP" });
+    expect(next.currentStep).toBe("step-1");
+    expect(next.optimisticStep).toBeUndefined();
+    expect(next.isPending).toBe(false);
+  });
+
+  it("sets the announcement text", () => {
+    const next = onboardingReducer(base, { type: "SET_ANNOUNCEMENT", payload: "Step 2 of 3" });
+    expect(next.announcementText).toBe("Step 2 of 3");
+  });
+
+  it("returns the same state for unknown actions", () => {
+    // @ts-expect-error — exercising the default branch with an invalid action.
+    expect(onboardingReducer(base, { type: "NOPE" })).toBe(base);
+  });
+});

--- a/frontend/src/components/onboarding-reducer.ts
+++ b/frontend/src/components/onboarding-reducer.ts
@@ -1,0 +1,52 @@
+/**
+ * State logic for the Onboarding Progress Tracker, extracted from the component
+ * so the optimistic-update lifecycle (optimistic → confirm/rollback) is a pure,
+ * independently testable unit rather than being tangled with the view.
+ */
+
+export interface OnboardingState {
+  currentStep: string | undefined;
+  /** Optimistic step id set immediately on click before the change is confirmed. */
+  optimisticStep: string | undefined;
+  announcementText: string;
+  /** Whether an optimistic update is awaiting confirmation. */
+  isPending: boolean;
+}
+
+export type OnboardingAction =
+  | { type: "SET_CURRENT_STEP"; payload: string }
+  | { type: "OPTIMISTIC_STEP"; payload: string }
+  | { type: "CONFIRM_STEP"; payload: string }
+  | { type: "ROLLBACK_STEP" }
+  | { type: "SET_ANNOUNCEMENT"; payload: string };
+
+export function createInitialOnboardingState(
+  currentStep?: string,
+): OnboardingState {
+  return {
+    currentStep,
+    optimisticStep: undefined,
+    announcementText: "",
+    isPending: false,
+  };
+}
+
+export function onboardingReducer(
+  state: OnboardingState,
+  action: OnboardingAction,
+): OnboardingState {
+  switch (action.type) {
+    case "SET_CURRENT_STEP":
+      return { ...state, currentStep: action.payload, optimisticStep: undefined, isPending: false };
+    case "OPTIMISTIC_STEP":
+      return { ...state, optimisticStep: action.payload, isPending: true };
+    case "CONFIRM_STEP":
+      return { ...state, currentStep: action.payload, optimisticStep: undefined, isPending: false };
+    case "ROLLBACK_STEP":
+      return { ...state, optimisticStep: undefined, isPending: false };
+    case "SET_ANNOUNCEMENT":
+      return { ...state, announcementText: action.payload };
+    default:
+      return state;
+  }
+}

--- a/frontend/src/hooks/useBalanceSync.test.ts
+++ b/frontend/src/hooks/useBalanceSync.test.ts
@@ -47,4 +47,66 @@ describe("useBalanceSync", () => {
 
     expect(global.fetch).toHaveBeenCalledTimes(2);
   });
+
+  it("fetches from Horizon and normalises balances when an address is given", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        balances: [
+          { asset_type: "native", balance: "42.5" },
+          { asset_type: "credit_alphanum4", asset_code: "USDC", balance: "10" },
+        ],
+      }),
+    });
+
+    const { result } = renderHook(() =>
+      useBalanceSync(null, null, { address: "GABC", pollingInterval: 0 })
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/accounts/GABC"),
+      expect.any(Object)
+    );
+    expect(result.current.balances).toEqual([
+      { code: "XLM", balance: "42.5" },
+      { code: "USDC", balance: "10" },
+    ]);
+    expect(result.current.lastUpdated).not.toBeNull();
+  });
+
+  it("does not fetch when disabled", () => {
+    global.fetch = vi.fn();
+    renderHook(() => useBalanceSync("m1", "k1", { enabled: false }));
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("applies an optimistic balance immediately without a network call", () => {
+    global.fetch = vi.fn();
+    const { result } = renderHook(() =>
+      useBalanceSync(null, null, { enabled: false })
+    );
+
+    act(() => {
+      result.current.applyOptimistic("XLM", "7.5");
+    });
+    expect(result.current.balances).toEqual([{ code: "XLM", balance: "7.5" }]);
+
+    act(() => {
+      result.current.applyOptimistic("XLM", "9");
+    });
+    expect(result.current.balances).toEqual([{ code: "XLM", balance: "9" }]);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("reports the balance as stale until the first successful sync", () => {
+    global.fetch = vi.fn();
+    const { result } = renderHook(() =>
+      useBalanceSync("m1", "k1", { enabled: false, pollingInterval: 1000 })
+    );
+    expect(result.current.isStale).toBe(true);
+  });
 });

--- a/frontend/src/hooks/useBalanceSync.ts
+++ b/frontend/src/hooks/useBalanceSync.ts
@@ -89,6 +89,20 @@ export function useBalanceSync(
     }
   }, [merchantId, apiKey, enabled, onUpdate, address, horizonUrl]);
 
+  /**
+   * Optimistically set a balance locally so the UI reflects a just-submitted
+   * change immediately; the next poll reconciles it with the authoritative value.
+   */
+  const applyOptimistic = useCallback((code: string, balance: string) => {
+    setBalances((prev) => {
+      const index = prev.findIndex((b) => b.code === code);
+      if (index === -1) return [...prev, { code, balance }];
+      const next = [...prev];
+      next[index] = { ...next[index], balance };
+      return next;
+    });
+  }, []);
+
   useEffect(() => {
     fetchBalances();
 
@@ -108,6 +122,7 @@ export function useBalanceSync(
     isLoading,
     lastUpdated,
     refresh: fetchBalances,
+    applyOptimistic,
     isStale: lastUpdated ? Date.now() - lastUpdated.getTime() > pollingInterval * 2 : true,
   };
 }


### PR DESCRIPTION
## Summary

Four small frontend changes across the Real-time Balance Sync and Onboarding Progress Tracker modules, bundled into one PR.

- **#805 — unit tests for Real-time Balance Sync** (`src/hooks/useBalanceSync.test.ts`): added coverage for the Horizon address path (with native→XLM normalisation), the disabled state, the new optimistic update, and the `isStale` flag.
- **#806 — screen reader support for Real-time Balance Sync** (`src/components/SupportPanel.tsx`): added a single authoritative visually-hidden `role="status"` live region that announces sync state ("Syncing…", "unfunded", "Balance synced: X CODE"), and made the visual balance row non-live so screen readers hear one clear message instead of raw element swaps.
- **#807 — optimistic updates in Real-time Balance Sync** (`src/hooks/useBalanceSync.ts`): added `applyOptimistic(code, balance)` so a just-submitted balance can be reflected immediately; the next poll reconciles it with the authoritative value.
- **#808 — refactor state logic for the Onboarding Progress Tracker** (`src/components/onboarding-reducer.ts`): extracted the reducer, its `OnboardingState`/`OnboardingAction` types and an initial-state factory out of the component into a pure module, decoupling state logic from the view and making it independently unit-testable. Component behaviour is unchanged.

## Test plan

- [x] `vitest run src/hooks/useBalanceSync.test.ts src/components/onboarding-reducer.test.ts` — **12 tests pass** (6 balance-sync + 6 onboarding-reducer)
- [x] `tsc --noEmit` — no type errors in any of the changed files

## Note (pre-existing, not introduced by this PR)

The repository's React component test environment fails on `main` with a jsdom `appendChild` error (verified on the unmodified tree), so component-render tests for `SupportPanel`/`OnboardingProgressTracker` cannot run locally. The work above is therefore covered by hook tests and a pure reducer test, which do run green; `tsc` confirms the component edits type-check.

Closes #805
Closes #806
Closes #807
Closes #808