### PR TITLE
feat(frontend): theme engine state refactor, toggle motion, engine/multisig tests

### DIFF
--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -80,9 +80,12 @@ export default function ThemeToggle() {
         {announcement}
       </div>
 
-      <button
+      <motion.button
         onClick={handleThemeToggle}
-        className={`flex h-9 w-9 items-center justify-center rounded-lg border transition-all active:scale-95 ${
+        whileHover={{ scale: 1.05 }}
+        whileTap={{ scale: 0.95 }}
+        transition={{ type: "spring", stiffness: 400, damping: 17 }}
+        className={`flex h-9 w-9 items-center justify-center rounded-lg border transition-colors ${
           error
             ? "border-red-500/50 bg-red-500/10 hover:bg-red-500/20"
             : "border-white/10 bg-white/5 hover:bg-white/10"
@@ -185,6 +188,7 @@ export default function ThemeToggle() {
           </motion.div>
         )}
       </AnimatePresence>
+      </motion.button>
 
       {/* Hidden description for screen readers */}
       <div id="theme-description" className="sr-only">

--- a/frontend/src/lib/multisig-optimistic.test.tsx
+++ b/frontend/src/lib/multisig-optimistic.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * Optimistic-update tests for the Multi-sig Approval flow (issue #797).
+ *
+ * `signTransaction` marks a signer as signed immediately (optimistically) and
+ * only attaches the real signature once the async signing settles. These tests
+ * capture that window and the eventual finalize + step advance.
+ */
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import {
+  MultisigProvider,
+  useMultisigState,
+  useMultisigActions,
+  type MultisigTransaction,
+} from "./multisig-context";
+
+const tx: MultisigTransaction = {
+  id: "tx-opt-1",
+  sourceAccount: "GSOURCE",
+  destination: "GDEST",
+  amount: "100",
+  assetCode: "USDC",
+  minSignatures: 2,
+  signers: [
+    { id: "s1", publicKey: "GPUB1", name: "Alice", weight: 1, hasSigned: false },
+    { id: "s2", publicKey: "GPUB2", name: "Bob", weight: 1, hasSigned: false },
+  ],
+  createdAt: "2024-01-01T00:00:00Z",
+  status: "pending",
+};
+
+function Consumer() {
+  const { transaction, signedCount, currentStep, error } = useMultisigState();
+  const { setTransaction, signTransaction } = useMultisigActions();
+  const s1 = transaction?.signers.find((s) => s.id === "s1");
+  const s2 = transaction?.signers.find((s) => s.id === "s2");
+  return (
+    <div>
+      <span data-testid="signed-count">{signedCount}</span>
+      <span data-testid="step">{currentStep}</span>
+      <span data-testid="error">{error || "no-error"}</span>
+      <span data-testid="s1-signed">{String(!!s1?.hasSigned)}</span>
+      <span data-testid="s1-has-signature">{String(!!s1?.signature)}</span>
+      <span data-testid="s2-signed">{String(!!s2?.hasSigned)}</span>
+      <button onClick={() => setTransaction(tx)}>set-tx</button>
+      <button onClick={() => signTransaction("s1")}>sign-s1</button>
+      <button onClick={() => signTransaction("s2")}>sign-s2</button>
+    </div>
+  );
+}
+
+const renderModal = () =>
+  render(
+    <MultisigProvider networkPassphrase="Test Network">
+      <Consumer />
+    </MultisigProvider>,
+  );
+
+describe("Multi-sig optimistic updates (#797)", () => {
+  it("marks the signer as signed optimistically before the signature settles", async () => {
+    renderModal();
+    fireEvent.click(screen.getByText("set-tx"));
+    await waitFor(() => expect(screen.getByTestId("signed-count")).toHaveTextContent("0"));
+
+    fireEvent.click(screen.getByText("sign-s1"));
+
+    // Optimistic: signer flips to signed immediately, before the async signature.
+    await waitFor(() => expect(screen.getByTestId("s1-signed")).toHaveTextContent("true"));
+    expect(screen.getByTestId("s1-has-signature")).toHaveTextContent("false");
+
+    // Settled: the real signature is attached once signing resolves.
+    await waitFor(
+      () => expect(screen.getByTestId("s1-has-signature")).toHaveTextContent("true"),
+      { timeout: 2000 },
+    );
+    expect(screen.getByTestId("signed-count")).toHaveTextContent("1");
+  });
+
+  it("advances to the submit step once the signature threshold is met", async () => {
+    renderModal();
+    fireEvent.click(screen.getByText("set-tx"));
+    await waitFor(() => expect(screen.getByTestId("signed-count")).toHaveTextContent("0"));
+
+    fireEvent.click(screen.getByText("sign-s1"));
+    await waitFor(
+      () => expect(screen.getByTestId("s1-has-signature")).toHaveTextContent("true"),
+      { timeout: 2000 },
+    );
+
+    fireEvent.click(screen.getByText("sign-s2"));
+    await waitFor(
+      () => {
+        expect(screen.getByTestId("s2-signed")).toHaveTextContent("true");
+        expect(screen.getByTestId("step")).toHaveTextContent("submit");
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  it("surfaces an error when signing without a transaction", async () => {
+    renderModal();
+    fireEvent.click(screen.getByText("sign-s1"));
+    await waitFor(() => expect(screen.getByTestId("error")).not.toHaveTextContent("no-error"));
+  });
+});

--- a/frontend/src/lib/theme-context.tsx
+++ b/frontend/src/lib/theme-context.tsx
@@ -6,6 +6,33 @@ import { ThemeProvider as NextThemesProvider } from "next-themes";
 export type ThemeMode = "light" | "dark" | "system";
 export type ResolvedTheme = "light" | "dark";
 
+/** Returns whether the OS currently prefers a dark color scheme. */
+function systemPrefersDark(): boolean {
+  return (
+    typeof globalThis !== "undefined" &&
+    !!globalThis.window &&
+    globalThis.window.matchMedia("(prefers-color-scheme: dark)").matches
+  );
+}
+
+/** Resolves a {@link ThemeMode} to a concrete light/dark theme. */
+export function resolveTheme(mode: ThemeMode, forced?: ResolvedTheme): ResolvedTheme {
+  if (forced) return forced;
+  if (mode === "system") return systemPrefersDark() ? "dark" : "light";
+  return mode;
+}
+
+/** Applies the resolved theme to the document root class and meta theme-color. */
+function applyThemeToDocument(resolved: ResolvedTheme): void {
+  if (typeof globalThis === "undefined" || !globalThis.document) return;
+  globalThis.document.documentElement.classList.remove("light", "dark");
+  globalThis.document.documentElement.classList.add(resolved);
+  const metaThemeColor = globalThis.document.querySelector('meta[name="theme-color"]');
+  if (metaThemeColor) {
+    metaThemeColor.setAttribute("content", resolved === "dark" ? "#0A0A0A" : "#FFFFFF");
+  }
+}
+
 interface ThemeContextType {
   theme: ThemeMode | undefined;
   resolvedTheme: ResolvedTheme | undefined;
@@ -50,25 +77,15 @@ export function ThemeProvider({
 
     try {
       setThemeState(newTheme);
-      
+
       if (typeof globalThis !== "undefined" && globalThis.window) {
         globalThis.localStorage.setItem(storageKey, newTheme);
-        
-        const mediaQuery = globalThis.window.matchMedia("(prefers-color-scheme: dark)");
-        const systemTheme = mediaQuery.matches ? "dark" : "light";
-        const resolved = newTheme === "system" ? systemTheme : newTheme;
-        
+
+        const resolved = resolveTheme(newTheme);
         setResolvedTheme(resolved);
-        
-        globalThis.document.documentElement.classList.remove("light", "dark");
-        globalThis.document.documentElement.classList.add(resolved);
-        
-        const metaThemeColor = globalThis.document.querySelector('meta[name="theme-color"]');
-        if (metaThemeColor) {
-          metaThemeColor.setAttribute("content", resolved === "dark" ? "#0A0A0A" : "#FFFFFF");
-        }
+        applyThemeToDocument(resolved);
       }
-      
+
       setError(null);
     } catch (err) {
       // Revert optimistic update
@@ -76,8 +93,7 @@ export function ThemeProvider({
       if (previousResolved) {
         setResolvedTheme(previousResolved);
         if (typeof globalThis !== "undefined" && globalThis.window) {
-          globalThis.document.documentElement.classList.remove("light", "dark");
-          globalThis.document.documentElement.classList.add(previousResolved);
+          applyThemeToDocument(previousResolved);
         }
       }
       
@@ -106,18 +122,10 @@ export function ThemeProvider({
     
     const updateResolvedTheme = () => {
       try {
-        const mediaQuery = globalThis.window.matchMedia("(prefers-color-scheme: dark)");
-        const systemTheme = mediaQuery.matches ? "dark" : "light";
-        const resolved = forcedTheme || (initialTheme === "system" ? systemTheme : initialTheme);
-        
+        const resolved = resolveTheme(initialTheme, forcedTheme);
+
         setResolvedTheme(resolved);
-        globalThis.document.documentElement.classList.remove("light", "dark");
-        globalThis.document.documentElement.classList.add(resolved);
-        
-        const metaThemeColor = globalThis.document.querySelector('meta[name="theme-color"]');
-        if (metaThemeColor) {
-          metaThemeColor.setAttribute("content", resolved === "dark" ? "#0A0A0A" : "#FFFFFF");
-        }
+        applyThemeToDocument(resolved);
       } catch (err) {
         const errorMessage = err instanceof Error ? err.message : "Failed to initialize theme";
         setError(errorMessage);

--- a/frontend/src/lib/theme-engine.test.tsx
+++ b/frontend/src/lib/theme-engine.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for the Dark Mode Theme Engine (issue #800).
+ *
+ * Self-contained and jsdom-compatible: it provides a controllable `matchMedia`
+ * mock and uses the real jsdom `document`/`localStorage`, so React Testing
+ * Library's `render` works against a real DOM root.
+ */
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import {
+  ThemeProvider,
+  useThemeState,
+  useThemeActions,
+  resolveTheme,
+} from "./theme-context";
+
+function mockMatchMedia(prefersDark: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: prefersDark,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+function Consumer() {
+  const { theme, resolvedTheme, isMounted, isDark, isLight, isSystem } = useThemeState();
+  const { setTheme, toggleTheme } = useThemeActions();
+  return (
+    <div>
+      <span data-testid="theme">{theme}</span>
+      <span data-testid="resolved">{resolvedTheme}</span>
+      <span data-testid="mounted">{String(isMounted)}</span>
+      <span data-testid="isDark">{String(isDark)}</span>
+      <span data-testid="isLight">{String(isLight)}</span>
+      <span data-testid="isSystem">{String(isSystem)}</span>
+      <button onClick={() => setTheme("dark")}>set-dark</button>
+      <button onClick={() => setTheme("light")}>set-light</button>
+      <button onClick={toggleTheme}>toggle</button>
+    </div>
+  );
+}
+
+const renderEngine = () =>
+  render(
+    <ThemeProvider>
+      <Consumer />
+    </ThemeProvider>,
+  );
+
+describe("Dark Mode Theme Engine (#800)", () => {
+  beforeEach(() => {
+    mockMatchMedia(false);
+    localStorage.clear();
+    document.documentElement.className = "";
+  });
+
+  describe("resolveTheme helper", () => {
+    it("resolves explicit light/dark modes verbatim", () => {
+      expect(resolveTheme("light")).toBe("light");
+      expect(resolveTheme("dark")).toBe("dark");
+    });
+
+    it("honors a forced theme over the requested mode", () => {
+      expect(resolveTheme("light", "dark")).toBe("dark");
+      expect(resolveTheme("system", "light")).toBe("light");
+    });
+
+    it("resolves system mode from the OS preference", () => {
+      mockMatchMedia(true);
+      expect(resolveTheme("system")).toBe("dark");
+      mockMatchMedia(false);
+      expect(resolveTheme("system")).toBe("light");
+    });
+  });
+
+  it("applies the dark class and persists the preference when set to dark", async () => {
+    renderEngine();
+    await waitFor(() => expect(screen.getByTestId("mounted")).toHaveTextContent("true"));
+
+    fireEvent.click(screen.getByText("set-dark"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("theme")).toHaveTextContent("dark");
+      expect(screen.getByTestId("resolved")).toHaveTextContent("dark");
+    });
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(localStorage.getItem("merchant-theme-preference")).toBe("dark");
+  });
+
+  it("swaps the document class from dark to light", async () => {
+    renderEngine();
+    await waitFor(() => expect(screen.getByTestId("mounted")).toHaveTextContent("true"));
+
+    fireEvent.click(screen.getByText("set-dark"));
+    await waitFor(() => expect(document.documentElement.classList.contains("dark")).toBe(true));
+
+    fireEvent.click(screen.getByText("set-light"));
+    await waitFor(() => {
+      expect(document.documentElement.classList.contains("light")).toBe(true);
+      expect(document.documentElement.classList.contains("dark")).toBe(false);
+    });
+  });
+
+  it("exposes correct derived flags via useThemeState", async () => {
+    renderEngine();
+    await waitFor(() => expect(screen.getByTestId("mounted")).toHaveTextContent("true"));
+
+    fireEvent.click(screen.getByText("set-dark"));
+    await waitFor(() => {
+      expect(screen.getByTestId("isDark")).toHaveTextContent("true");
+      expect(screen.getByTestId("isLight")).toHaveTextContent("false");
+      expect(screen.getByTestId("isSystem")).toHaveTextContent("false");
+    });
+  });
+
+  it("cycles light -> dark -> system via toggleTheme", async () => {
+    renderEngine();
+    await waitFor(() => expect(screen.getByTestId("mounted")).toHaveTextContent("true"));
+
+    // Default is system; first toggle lands on light.
+    fireEvent.click(screen.getByText("toggle"));
+    await waitFor(() => expect(screen.getByTestId("theme")).toHaveTextContent("light"));
+
+    fireEvent.click(screen.getByText("toggle"));
+    await waitFor(() => expect(screen.getByTestId("theme")).toHaveTextContent("dark"));
+
+    fireEvent.click(screen.getByText("toggle"));
+    await waitFor(() => expect(screen.getByTestId("theme")).toHaveTextContent("system"));
+  });
+});


### PR DESCRIPTION
## Summary

Four frontend tasks across the Dark Mode Theme Engine and the Multi-sig Approval flow.

### #798 — Refactor state logic for Dark Mode Theme Engine
Extracted two helpers in `theme-context.tsx` — `resolveTheme(mode, forced?)` and `applyThemeToDocument(resolved)` — and reused them in `setTheme`, the optimistic-revert path, and initialization. This removes the theme-resolution + DOM/meta-color logic that was duplicated three times. Behavior is unchanged.

### #799 — framer-motion animations for Dark Mode Theme Engine
The `ThemeToggle` icon transitions already use `motion`/`AnimatePresence`; this adds spring `whileHover`/`whileTap` micro-interactions to the toggle button itself (`<button>` → `motion.button`). It also **fixes a pre-existing unclosed `<button>` JSX tag** that left `ThemeToggle.tsx` failing to compile (`TS17014: JSX fragment has no corresponding closing tag`).

### #800 — Add unit tests for Dark Mode Theme Engine
New `theme-engine.test.tsx` with a self-contained, jsdom-compatible setup (controllable `matchMedia` mock, real `document`/`localStorage`). Covers `resolveTheme`, dark-class application + localStorage persistence, light↔dark swap, derived `useThemeState` flags, and the `toggleTheme` cycle. **7 tests, all passing.**

### #797 — Enable optimistic updates in Multi-sig Approval Modal
`signTransaction` already applies an optimistic update (marks the signer signed immediately, attaches the real signature once signing settles, reverts on error). New `multisig-optimistic.test.tsx` locks this in: it asserts the optimistic mark precedes the settled signature, the flow advances to the submit step at threshold, and signing without a transaction surfaces an error. **3 tests, all passing.**

## Test plan
- [x] `npx vitest run src/lib/theme-engine.test.tsx` — 7/7 pass
- [x] `npx vitest run src/lib/multisig-optimistic.test.tsx` — 3/3 pass
- [x] `npx tsc --noEmit` — `ThemeToggle.tsx` / `theme-context.tsx` compile cleanly (ThemeToggle did not compile before this PR)

## Out of scope (pre-existing on `main`)
The existing `theme-context.test.tsx`, `ThemeToggle.test.tsx`, and `multisig-context.test.tsx` fail on `main`: their `beforeEach` replaces `globalThis.document`/`window` (which breaks RTL's `render`) and `multisig-context.test.tsx` calls `jest.clearAllMocks()` (this project uses Vitest, so `jest` is undefined). The new test files added here avoid both pitfalls and pass independently. There is also a pre-existing case-collision between `KYCSubmissionForm.tsx` and `KycSubmissionForm.tsx`. These are left untouched.

Closes #800
Closes #799
Closes #798
Closes #797