### PR TITLE
feat(frontend): improve screen reader support and enable optimistic u…

### DIFF
--- a/frontend/src/components/PaymentSuccessAnimation.test.tsx
+++ b/frontend/src/components/PaymentSuccessAnimation.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/vitest";
+import React from "react";
 import confetti from "canvas-confetti";
 import { PaymentSuccessAnimation } from "./PaymentSuccessAnimation";
 
@@ -13,10 +14,46 @@ vi.mock("canvas-confetti", () => ({
   default: vi.fn(),
 }));
 
+// ── framer-motion mock ────────────────────────────────────────────────────────
+// Hoisted so useReducedMotion can be controlled per-test (#980)
+const { mockUseReducedMotion } = vi.hoisted(() => ({
+  mockUseReducedMotion: vi.fn(() => false as boolean | null),
+}));
+
+const MOTION_PROPS = [
+  "initial", "animate", "exit", "transition", "variants", "viewport",
+  "whileInView", "whileHover", "whileTap", "whileFocus", "whileDrag",
+  "layout", "layoutId", "custom", "drag", "dragConstraints",
+  "onAnimationStart", "onAnimationComplete", "onUpdate",
+];
+
+function mkMotion(tag: string) {
+  return React.forwardRef(function MotionStub({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>, ref: React.Ref<unknown>) {
+    const domProps = { ...props };
+    MOTION_PROPS.forEach((k) => delete domProps[k]);
+    return React.createElement(tag, { ...domProps, ref }, children);
+  });
+}
+
+vi.mock("framer-motion", () => ({
+  motion: {
+    div: mkMotion("div"),
+    button: mkMotion("button"),
+    h1: mkMotion("h1"),
+    p: mkMotion("p"),
+    path: mkMotion("path"),
+  },
+  AnimatePresence: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  useReducedMotion: mockUseReducedMotion,
+}));
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 describe("PaymentSuccessAnimation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useRealTimers();
+    mockUseReducedMotion.mockReturnValue(false);
   });
 
   // ── Render / visibility ────────────────────────────────────────────────────
@@ -45,11 +82,10 @@ describe("PaymentSuccessAnimation", () => {
     expect(screen.getByText("0 XLM")).toBeInTheDocument();
   });
 
-  // ── Optimistic updates ─────────────────────────────────────────────────────
+  // ── Optimistic updates (#981) ──────────────────────────────────────────────
 
   it("shows optimistic badge when isOptimistic is true", () => {
     render(<PaymentSuccessAnimation show isOptimistic amount="50" asset="XLM" />);
-    // The optimistic live region + note text should be present
     expect(screen.getByText("payment.optimisticNote")).toBeInTheDocument();
   });
 
@@ -64,14 +100,82 @@ describe("PaymentSuccessAnimation", () => {
     expect(badge).toHaveAttribute("aria-live", "polite");
   });
 
+  it("continue button is disabled during optimistic dismiss", async () => {
+    let resolveOnComplete!: () => void;
+    const onComplete = vi.fn().mockImplementation(
+      () => new Promise<void>((resolve) => { resolveOnComplete = resolve; })
+    );
+    render(<PaymentSuccessAnimation show onComplete={onComplete} />);
+
+    await userEvent.click(screen.getByLabelText("common.continue"));
+
+    expect(screen.getByLabelText("common.continue")).toBeDisabled();
+    expect(screen.getByLabelText("common.continue")).toHaveAttribute("aria-busy", "true");
+
+    act(() => resolveOnComplete());
+  });
+
+  it("close button is disabled during optimistic dismiss", async () => {
+    let resolveOnComplete!: () => void;
+    const onComplete = vi.fn().mockImplementation(
+      () => new Promise<void>((resolve) => { resolveOnComplete = resolve; })
+    );
+    render(<PaymentSuccessAnimation show onComplete={onComplete} />);
+
+    await userEvent.click(screen.getByLabelText("common.close"));
+
+    expect(screen.getByLabelText("common.close")).toBeDisabled();
+    expect(screen.getByLabelText("common.close")).toHaveAttribute("aria-busy", "true");
+
+    act(() => resolveOnComplete());
+  });
+
+  it("shows spinner on continue button during dismiss", async () => {
+    let resolveOnComplete!: () => void;
+    const onComplete = vi.fn().mockImplementation(
+      () => new Promise<void>((resolve) => { resolveOnComplete = resolve; })
+    );
+    render(<PaymentSuccessAnimation show onComplete={onComplete} />);
+
+    await userEvent.click(screen.getByLabelText("common.continue"));
+
+    expect(screen.getByTestId("dismiss-spinner")).toBeInTheDocument();
+
+    act(() => resolveOnComplete());
+  });
+
+  it("rolls back dismiss state and re-enables buttons when onComplete throws", async () => {
+    const onComplete = vi.fn().mockRejectedValue(new Error("Network error"));
+    render(<PaymentSuccessAnimation show onComplete={onComplete} />);
+
+    await userEvent.click(screen.getByLabelText("common.continue"));
+
+    expect(screen.getByLabelText("common.continue")).not.toBeDisabled();
+    expect(screen.getByLabelText("common.continue")).not.toHaveAttribute("aria-busy", "true");
+  });
+
+  it("prevents double-dismiss while already dismissing", async () => {
+    let resolveOnComplete!: () => void;
+    const onComplete = vi.fn().mockImplementation(
+      () => new Promise<void>((resolve) => { resolveOnComplete = resolve; })
+    );
+    render(<PaymentSuccessAnimation show onComplete={onComplete} />);
+
+    await userEvent.click(screen.getByLabelText("common.continue"));
+
+    // onComplete should have been called exactly once; button is now disabled
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(screen.getByLabelText("common.continue")).toBeDisabled();
+
+    act(() => resolveOnComplete());
+  });
+
   // ── Confetti ───────────────────────────────────────────────────────────────
 
   it("triggers confetti once on show", () => {
     vi.useFakeTimers();
     const { rerender } = render(<PaymentSuccessAnimation show amount="1" asset="XLM" />);
-    // Initial render fires confetti
     expect(confetti).toHaveBeenCalledTimes(1);
-    // Re-render with same show=true should NOT fire again
     rerender(<PaymentSuccessAnimation show amount="1" asset="XLM" />);
     expect(confetti).toHaveBeenCalledTimes(1);
     vi.useRealTimers();
@@ -82,7 +186,6 @@ describe("PaymentSuccessAnimation", () => {
     render(<PaymentSuccessAnimation show />);
     expect(confetti).toHaveBeenCalledTimes(1);
     act(() => { vi.advanceTimersByTime(200); });
-    // Flanking calls: +2 more
     expect(confetti).toHaveBeenCalledTimes(3);
     vi.useRealTimers();
   });
@@ -94,6 +197,15 @@ describe("PaymentSuccessAnimation", () => {
     rerender(<PaymentSuccessAnimation show={false} />);
     rerender(<PaymentSuccessAnimation show />);
     expect(confetti).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it("skips confetti when prefersReducedMotion is true (#980)", () => {
+    mockUseReducedMotion.mockReturnValue(true);
+    vi.useFakeTimers();
+    render(<PaymentSuccessAnimation show />);
+    act(() => { vi.advanceTimersByTime(200); });
+    expect(confetti).not.toHaveBeenCalled();
     vi.useRealTimers();
   });
 
@@ -149,7 +261,7 @@ describe("PaymentSuccessAnimation", () => {
     expect(onComplete).not.toHaveBeenCalled();
   });
 
-  // ── Screen reader / accessibility ─────────────────────────────────────────
+  // ── Screen reader / accessibility (#980) ──────────────────────────────────
 
   it("has expected dialog ARIA semantics", () => {
     render(<PaymentSuccessAnimation show amount="20" asset="USDC" />);
@@ -166,6 +278,26 @@ describe("PaymentSuccessAnimation", () => {
     expect(status).toHaveAttribute("aria-live", "assertive");
     expect(status).toHaveAttribute("aria-atomic", "true");
     expect(status).toHaveTextContent("payment.successAnnounce");
+  });
+
+  it("renders dynamic announcement region with data-testid", () => {
+    render(<PaymentSuccessAnimation show />);
+    expect(screen.getByTestId("sr-announcement")).toBeInTheDocument();
+  });
+
+  it("announces network confirmation when isOptimistic changes from true to false", () => {
+    const { rerender } = render(<PaymentSuccessAnimation show isOptimistic />);
+    rerender(<PaymentSuccessAnimation show isOptimistic={false} />);
+    expect(screen.getByTestId("sr-announcement")).toHaveTextContent("payment.networkConfirmed");
+  });
+
+  it("announces error in live region when onComplete throws", async () => {
+    const onComplete = vi.fn().mockRejectedValue(new Error("Stellar network error"));
+    render(<PaymentSuccessAnimation show onComplete={onComplete} />);
+
+    await userEvent.click(screen.getByLabelText("common.continue"));
+
+    expect(screen.getByTestId("sr-announcement")).toHaveTextContent("Stellar network error");
   });
 
   it("close button has a descriptive accessible label", () => {

--- a/frontend/src/components/PaymentSuccessAnimation.tsx
+++ b/frontend/src/components/PaymentSuccessAnimation.tsx
@@ -1,19 +1,21 @@
 "use client";
 
-import React, { useEffect, useRef } from "react";
-import { motion, AnimatePresence, type Variants } from "framer-motion";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { motion, AnimatePresence, useReducedMotion, type Variants } from "framer-motion";
 import confetti from "canvas-confetti";
 import { useTranslations } from "next-intl";
 
 interface PaymentSuccessAnimationProps {
   show: boolean;
-  onComplete?: () => void;
+  onComplete?: () => void | Promise<void>;
   amount?: string;
   asset?: string;
   txId?: string;
   /** When true, the component indicates an optimistic (pre-confirmation) success state */
   isOptimistic?: boolean;
 }
+
+// ── Full-motion animation variants ──────────────────────────────────────────
 
 const containerVariants: Variants = {
   hidden: { opacity: 0, scale: 0.9 },
@@ -51,6 +53,24 @@ const checkVariants: Variants = {
   },
 };
 
+// ── Reduced-motion variants (#980) ───────────────────────────────────────────
+
+const containerVariantsReduced: Variants = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1, transition: { duration: 0.2 } },
+  exit: { opacity: 0, transition: { duration: 0.15 } },
+};
+
+const childVariantsReduced: Variants = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1, transition: { duration: 0.15 } },
+};
+
+const checkVariantsReduced: Variants = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1, transition: { duration: 0.2 } },
+};
+
 export const PaymentSuccessAnimation: React.FC<PaymentSuccessAnimationProps> = ({
   show,
   onComplete,
@@ -60,11 +80,56 @@ export const PaymentSuccessAnimation: React.FC<PaymentSuccessAnimationProps> = (
   isOptimistic = false,
 }) => {
   const t = useTranslations();
+  // Respect OS-level "prefer reduced motion" setting (#980)
+  const prefersReducedMotion = useReducedMotion();
   const hasTriggeredConfettiRef = useRef(false);
   const completeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const prevIsOptimisticRef = useRef(isOptimistic);
 
+  // Optimistic dismiss state (#981)
+  const [isDismissing, setIsDismissing] = useState(false);
+  // Dynamic live-region text for state transitions (#980, #981)
+  const [announcementText, setAnnouncementText] = useState("");
+
+  // Reset dismiss state when dialog closes
+  useEffect(() => {
+    if (!show) {
+      setIsDismissing(false);
+      setAnnouncementText("");
+    }
+  }, [show]);
+
+  // Announce network confirmation when optimistic state resolves (#980)
+  useEffect(() => {
+    if (!show) return;
+    if (prevIsOptimisticRef.current === true && !isOptimistic) {
+      setAnnouncementText(
+        t("payment.networkConfirmed") || "Payment confirmed on the Stellar network."
+      );
+    }
+    prevIsOptimisticRef.current = isOptimistic;
+  }, [isOptimistic, show, t]);
+
+  // Optimistic dismiss handler — UI responds immediately, rolls back on error (#981)
+  const handleDismiss = useCallback(async () => {
+    if (isDismissing) return;
+    setIsDismissing(true);
+    setAnnouncementText(t("payment.dismissing") || "Processing…");
+    try {
+      await onComplete?.();
+    } catch (err) {
+      const msg =
+        err instanceof Error
+          ? err.message
+          : t("common.error") || "Something went wrong. Please try again.";
+      setIsDismissing(false);
+      setAnnouncementText(msg);
+    }
+  }, [isDismissing, onComplete, t]);
+
+  // Confetti + auto-dismiss timer
   useEffect(() => {
     if (!show) {
       hasTriggeredConfettiRef.current = false;
@@ -75,39 +140,40 @@ export const PaymentSuccessAnimation: React.FC<PaymentSuccessAnimationProps> = (
       return;
     }
 
-    // Focus the close button when the dialog opens for keyboard accessibility
     const focusTimer = setTimeout(() => {
       closeButtonRef.current?.focus();
     }, 100);
 
     if (!hasTriggeredConfettiRef.current) {
       hasTriggeredConfettiRef.current = true;
-      const accent = "#00F5D4";
-      const secondary = "#6C5CE7";
-      confetti({
-        particleCount: 120,
-        spread: 78,
-        startVelocity: 36,
-        origin: { y: 0.65 },
-        colors: [accent, secondary, "#00D4AA", "#ffffff"],
-      });
-      // Flanking burst 200ms later
-      setTimeout(() => {
+      // Skip confetti for users who prefer reduced motion (#980)
+      if (!prefersReducedMotion) {
+        const accent = "#00F5D4";
+        const secondary = "#6C5CE7";
         confetti({
-          particleCount: 40,
-          spread: 120,
-          startVelocity: 28,
-          origin: { x: 0.3, y: 0.7 },
-          colors: [accent, secondary],
+          particleCount: 120,
+          spread: 78,
+          startVelocity: 36,
+          origin: { y: 0.65 },
+          colors: [accent, secondary, "#00D4AA", "#ffffff"],
         });
-        confetti({
-          particleCount: 40,
-          spread: 120,
-          startVelocity: 28,
-          origin: { x: 0.7, y: 0.7 },
-          colors: [accent, secondary],
-        });
-      }, 200);
+        setTimeout(() => {
+          confetti({
+            particleCount: 40,
+            spread: 120,
+            startVelocity: 28,
+            origin: { x: 0.3, y: 0.7 },
+            colors: [accent, secondary],
+          });
+          confetti({
+            particleCount: 40,
+            spread: 120,
+            startVelocity: 28,
+            origin: { x: 0.7, y: 0.7 },
+            colors: [accent, secondary],
+          });
+        }, 200);
+      }
     }
 
     completeTimerRef.current = setTimeout(() => {
@@ -121,14 +187,14 @@ export const PaymentSuccessAnimation: React.FC<PaymentSuccessAnimationProps> = (
         completeTimerRef.current = null;
       }
     };
-  }, [show, onComplete]);
+  }, [show, onComplete, prefersReducedMotion]);
 
-  // Trap focus within the dialog while it is open
+  // Focus trap + keyboard handling
   useEffect(() => {
     if (!show) return;
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
-        onComplete?.();
+        void handleDismiss();
         return;
       }
       if (e.key !== "Tab") return;
@@ -156,25 +222,29 @@ export const PaymentSuccessAnimation: React.FC<PaymentSuccessAnimationProps> = (
     };
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [show, onComplete]);
+  }, [show, handleDismiss]);
 
   if (!show) return null;
+
+  // Pick variants based on reduced-motion preference (#980)
+  const activeContainerVariants = prefersReducedMotion ? containerVariantsReduced : containerVariants;
+  const activeChildVariants = prefersReducedMotion ? childVariantsReduced : childVariants;
+  const activeCheckVariants = prefersReducedMotion ? checkVariantsReduced : checkVariants;
 
   const successAnnounce =
     t("payment.successAnnounce") ||
     `Payment successful! ${amount} ${asset} has been received.`;
 
-  const optimisticNote =
-    isOptimistic
-      ? t("payment.optimisticNote") || "Transaction submitted — awaiting network confirmation."
-      : null;
+  const optimisticNote = isOptimistic
+    ? t("payment.optimisticNote") || "Transaction submitted — awaiting network confirmation."
+    : null;
 
   return (
     <AnimatePresence>
       <motion.div
         ref={containerRef}
         className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4 backdrop-blur-sm"
-        variants={containerVariants}
+        variants={activeContainerVariants}
         initial="hidden"
         animate="visible"
         exit="exit"
@@ -183,7 +253,7 @@ export const PaymentSuccessAnimation: React.FC<PaymentSuccessAnimationProps> = (
         aria-labelledby="payment-success-title"
         aria-describedby="payment-success-description"
       >
-        {/* Live region — announced immediately by screen readers */}
+        {/* Initial success announcement — assertive so screen readers interrupt (#980) */}
         <div
           className="sr-only"
           role="status"
@@ -193,9 +263,19 @@ export const PaymentSuccessAnimation: React.FC<PaymentSuccessAnimationProps> = (
           {successAnnounce}
         </div>
 
+        {/* Dynamic state announcements: confirmation, errors, pending (#980, #981) */}
+        <div
+          className="sr-only"
+          aria-live="polite"
+          aria-atomic="true"
+          data-testid="sr-announcement"
+        >
+          {announcementText}
+        </div>
+
         <motion.div
           className="relative w-full max-w-md overflow-hidden rounded-3xl border border-accent/30 bg-gradient-to-br from-black via-gray-900 to-black p-8 text-center shadow-2xl"
-          variants={childVariants}
+          variants={activeChildVariants}
         >
           {/* Subtle radial glow */}
           <div
@@ -203,13 +283,15 @@ export const PaymentSuccessAnimation: React.FC<PaymentSuccessAnimationProps> = (
             className="pointer-events-none absolute -right-12 -top-12 h-48 w-48 rounded-full bg-accent/10 blur-3xl"
           />
 
-          {/* Close button */}
+          {/* Close button — aria-busy signals pending dismiss to screen readers (#981) */}
           <motion.button
             ref={closeButtonRef}
-            onClick={onComplete}
-            className="absolute right-4 top-4 z-10 flex h-8 w-8 items-center justify-center rounded-full text-slate-500 transition-colors hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+            onClick={handleDismiss}
+            disabled={isDismissing}
+            aria-busy={isDismissing}
+            className="absolute right-4 top-4 z-10 flex h-8 w-8 items-center justify-center rounded-full text-slate-500 transition-colors hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 disabled:cursor-not-allowed disabled:opacity-50"
             aria-label={t("common.close") || "Close success animation"}
-            variants={childVariants}
+            variants={activeChildVariants}
             whileHover={{ scale: 1.1 }}
             whileTap={{ scale: 0.95 }}
           >
@@ -230,12 +312,16 @@ export const PaymentSuccessAnimation: React.FC<PaymentSuccessAnimationProps> = (
           {/* Animated success icon */}
           <motion.div
             className="relative mx-auto mb-6 flex h-20 w-20 items-center justify-center"
-            variants={childVariants}
+            variants={activeChildVariants}
           >
-            {/* Pulsing glow ring */}
+            {/* Pulsing glow ring — disabled when reduced motion is preferred (#980) */}
             <motion.div
               className="absolute inset-0 rounded-full bg-accent/20"
-              animate={{ scale: [1, 1.22, 1], opacity: [0.45, 0.9, 0.45] }}
+              animate={
+                prefersReducedMotion
+                  ? {}
+                  : { scale: [1, 1.22, 1], opacity: [0.45, 0.9, 0.45] }
+              }
               transition={{ duration: 1.8, repeat: Infinity, ease: "easeInOut" }}
               aria-hidden="true"
             />
@@ -247,7 +333,7 @@ export const PaymentSuccessAnimation: React.FC<PaymentSuccessAnimationProps> = (
             {/* Check icon */}
             <motion.div
               className="relative z-10 flex h-full w-full items-center justify-center"
-              variants={checkVariants}
+              variants={activeCheckVariants}
               aria-hidden="true"
             >
               <svg
@@ -263,7 +349,11 @@ export const PaymentSuccessAnimation: React.FC<PaymentSuccessAnimationProps> = (
                   d="M5 13l4 4L19 7"
                   initial={{ pathLength: 0 }}
                   animate={{ pathLength: 1 }}
-                  transition={{ duration: 0.5, ease: "easeOut", delay: 0.2 }}
+                  transition={{
+                    duration: prefersReducedMotion ? 0 : 0.5,
+                    ease: "easeOut",
+                    delay: prefersReducedMotion ? 0 : 0.2,
+                  }}
                 />
               </svg>
             </motion.div>
@@ -273,7 +363,7 @@ export const PaymentSuccessAnimation: React.FC<PaymentSuccessAnimationProps> = (
           <motion.h1
             id="payment-success-title"
             className="mb-3 text-3xl font-bold tracking-tight text-white"
-            variants={childVariants}
+            variants={activeChildVariants}
           >
             {t("payment.successTitle") || "Payment Successful!"}
           </motion.h1>
@@ -282,14 +372,11 @@ export const PaymentSuccessAnimation: React.FC<PaymentSuccessAnimationProps> = (
           {isOptimistic && (
             <motion.div
               className="mb-3 inline-flex items-center gap-1.5 rounded-full border border-yellow-400/30 bg-yellow-400/10 px-3 py-1 text-xs font-medium text-yellow-300"
-              variants={childVariants}
+              variants={activeChildVariants}
               role="status"
               aria-live="polite"
             >
-              <span
-                className="relative flex h-1.5 w-1.5"
-                aria-hidden="true"
-              >
+              <span className="relative flex h-1.5 w-1.5" aria-hidden="true">
                 <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-yellow-400/75" />
                 <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-yellow-400" />
               </span>
@@ -300,7 +387,7 @@ export const PaymentSuccessAnimation: React.FC<PaymentSuccessAnimationProps> = (
           {/* Amount block */}
           <motion.div
             className="mb-4 rounded-xl bg-accent/10 p-4"
-            variants={childVariants}
+            variants={activeChildVariants}
           >
             <p className="mb-1 text-sm text-slate-400">
               {t("payment.amountReceived") || "Amount Received"}
@@ -314,7 +401,7 @@ export const PaymentSuccessAnimation: React.FC<PaymentSuccessAnimationProps> = (
           <motion.p
             id="payment-success-description"
             className="mb-6 text-slate-400"
-            variants={childVariants}
+            variants={activeChildVariants}
           >
             {t("payment.successMessage") ||
               "Your payment has been processed successfully. The transaction is now confirmed on the Stellar network."}
@@ -324,7 +411,7 @@ export const PaymentSuccessAnimation: React.FC<PaymentSuccessAnimationProps> = (
           {txId ? (
             <motion.div
               className="mb-6 rounded-lg bg-slate-800/50 p-3"
-              variants={childVariants}
+              variants={activeChildVariants}
             >
               <p className="mb-1 text-xs text-slate-500">
                 {t("payment.transactionId") || "Transaction ID"}
@@ -333,21 +420,46 @@ export const PaymentSuccessAnimation: React.FC<PaymentSuccessAnimationProps> = (
             </motion.div>
           ) : null}
 
-          {/* CTA */}
+          {/* CTA — shows spinner and disables during optimistic dismiss (#981) */}
           <motion.div
             className="flex w-full flex-col gap-3"
-            variants={childVariants}
+            variants={activeChildVariants}
           >
             <button
-              onClick={onComplete}
-              className="flex items-center justify-center rounded-xl bg-accent px-6 py-3 font-semibold text-black transition-all hover:bg-accent/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+              onClick={handleDismiss}
+              disabled={isDismissing}
+              aria-busy={isDismissing}
+              className="flex items-center justify-center gap-2 rounded-xl bg-accent px-6 py-3 font-semibold text-black transition-all hover:bg-accent/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black disabled:cursor-not-allowed disabled:opacity-70"
               aria-label={t("common.continue") || "Continue"}
             >
+              {isDismissing && (
+                <svg
+                  className="h-4 w-4 animate-spin"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                  data-testid="dismiss-spinner"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                  />
+                </svg>
+              )}
               {t("common.continue") || "Continue"}
             </button>
           </motion.div>
 
-          {/* Keyboard hint for screen readers */}
+          {/* Keyboard hint for screen readers (#980) */}
           <p className="sr-only">
             {t("payment.successHint") ||
               "Press Escape or the close button to dismiss this message."}


### PR DESCRIPTION
 Add useReducedMotion support — skips confetti and uses fade-only animation variants when the OS reduce-motion preference is active
Add dynamic polite live region (data-testid=sr-announcement) that announces network confirmation when isOptimistic transitions from true to false
 Async handleDismiss with optimistic UI — Continue/Close buttons immediately show a loading spinner and aria-busy=true, then roll back (re-enable buttons + announce error) if onComplete rejects
 Escape key now routes through handleDismiss for consistent behavior
- Add framer-motion mock (vi.hoisted + mkMotion helper) and comprehensive tests covering reduced-motion, pending state, rollback, and SR announcements

Closes #980
Closes #981
Closes #982 
Closes #983