### PR TITLE
feat(frontend): improve KYC Submission Form - screen reader support a…

### DIFF
--- a/frontend/src/components/KycSubmissionForm.test.tsx
+++ b/frontend/src/components/KycSubmissionForm.test.tsx
@@ -412,4 +412,134 @@ describe("KycSubmissionForm", () => {
     render(React.createElement(KycSubmissionForm));
     expect(screen.getByRole("region")).toBeInTheDocument();
   });
+
+  // ── Screen reader support ─────────────────────────────────────────────────
+
+  it("step listitems have descriptive aria-labels including step name and status", () => {
+    const { container } = render(React.createElement(KycSubmissionForm));
+    const items = container.querySelectorAll('[role="listitem"]');
+    expect(items[0]).toHaveAttribute("aria-label", expect.stringContaining("personalInfo"));
+    expect(items[0]).toHaveAttribute("aria-label", expect.stringContaining("current"));
+    expect(items[1]).toHaveAttribute("aria-label", expect.stringContaining("addressInfo"));
+    expect(items[1]).toHaveAttribute("aria-label", expect.stringContaining("upcoming"));
+  });
+
+  it("step listitem status updates to completed after advancing past it", () => {
+    const { container } = render(React.createElement(KycSubmissionForm));
+    navigateToStep(1);
+    const items = container.querySelectorAll('[role="listitem"]');
+    expect(items[0]).toHaveAttribute("aria-label", expect.stringContaining("completed"));
+    expect(items[1]).toHaveAttribute("aria-label", expect.stringContaining("current"));
+  });
+
+  it("progressbar aria-label includes current step name", () => {
+    render(React.createElement(KycSubmissionForm));
+    const progressbar = screen.getByRole("progressbar");
+    expect(progressbar).toHaveAttribute("aria-label", expect.stringContaining("personalInfo"));
+  });
+
+  it("progressbar aria-label updates to next step name after navigation", () => {
+    render(React.createElement(KycSubmissionForm));
+    navigateToStep(1);
+    const progressbar = screen.getByRole("progressbar");
+    expect(progressbar).toHaveAttribute("aria-label", expect.stringContaining("addressInfo"));
+  });
+
+  it("back button has descriptive aria-label with destination step name", () => {
+    render(React.createElement(KycSubmissionForm));
+    navigateToStep(1);
+    const backBtn = screen.getByText("back").closest("button")!;
+    expect(backBtn).toHaveAttribute("aria-label", expect.stringContaining("personalInfo"));
+  });
+
+  it("next button has descriptive aria-label with destination step name", () => {
+    render(React.createElement(KycSubmissionForm));
+    const nextBtn = screen.getByText("next").closest("button")!;
+    expect(nextBtn).toHaveAttribute("aria-label", expect.stringContaining("addressInfo"));
+  });
+
+  // ── Additional unit tests ─────────────────────────────────────────────────
+
+  it("shows validation error message text for required fields", () => {
+    render(React.createElement(KycSubmissionForm));
+    fireEvent.click(screen.getByText("next"));
+    expect(screen.getAllByText("required").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("sets aria-describedby on invalid firstName input pointing to error element", () => {
+    render(React.createElement(KycSubmissionForm));
+    fireEvent.click(screen.getByText("next"));
+    const firstNameInput = screen.getByPlaceholderText("firstName");
+    const describedBy = firstNameInput.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    // useId() produces IDs with colons — use getElementById, not querySelector
+    const errorEl = document.getElementById(describedBy!);
+    expect(errorEl).toBeInTheDocument();
+  });
+
+  it("clears validation errors after filling required fields and navigating", () => {
+    render(React.createElement(KycSubmissionForm));
+    fireEvent.click(screen.getByText("next"));
+    expect(screen.getByPlaceholderText("firstName")).toHaveAttribute("aria-invalid", "true");
+
+    fillPersonalStep();
+    fireEvent.click(screen.getByText("next"));
+    fireEvent.click(screen.getByText("back"));
+    expect(screen.getByPlaceholderText("firstName")).toHaveAttribute("aria-invalid", "false");
+  });
+
+  it("accepts file upload on idBack input", () => {
+    render(React.createElement(KycSubmissionForm));
+    navigateToStep(2);
+    const idBackInput = screen.getByLabelText("idBack") as HTMLInputElement;
+    const file = new File(["content"], "id-back.png", { type: "image/png" });
+    fireEvent.change(idBackInput, { target: { files: [file] } });
+    expect(idBackInput.files?.[0]).toBe(file);
+  });
+
+  it("accepts file upload on selfie input", () => {
+    render(React.createElement(KycSubmissionForm));
+    navigateToStep(2);
+    const selfieInput = screen.getByLabelText("selfie") as HTMLInputElement;
+    const file = new File(["content"], "selfie.jpg", { type: "image/jpeg" });
+    fireEvent.change(selfieInput, { target: { files: [file] } });
+    expect(selfieInput.files?.[0]).toBe(file);
+  });
+
+  it("updates idType select on documents step", () => {
+    render(React.createElement(KycSubmissionForm));
+    navigateToStep(2);
+    const select = screen.getByLabelText("idType") as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "passport" } });
+    expect(select.value).toBe("passport");
+  });
+
+  it("updates idNumber field on documents step", () => {
+    render(React.createElement(KycSubmissionForm));
+    navigateToStep(2);
+    const idNumberInput = screen.getByPlaceholderText("idNumber") as HTMLInputElement;
+    fireEvent.change(idNumberInput, { target: { value: "A1234567" } });
+    expect(idNumberInput.value).toBe("A1234567");
+  });
+
+  it("review step shows dash for empty optional fields", () => {
+    render(React.createElement(KycSubmissionForm));
+    fillPersonalStep();
+    fireEvent.click(screen.getByText("next")); // → address
+    fireEvent.click(screen.getByText("next")); // → documents
+    fireEvent.click(screen.getByText("next")); // → review
+    // city was not filled, so it renders the placeholder dash
+    const dashes = screen.getAllByText("—");
+    expect(dashes.length).toBeGreaterThan(0);
+  });
+
+  it("shows error alert in review step when submission fails", async () => {
+    (global.fetch as any).mockResolvedValue({ ok: false });
+    render(React.createElement(KycSubmissionForm));
+    navigateToStep(3);
+    fireEvent.click(screen.getByText("submit"));
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/components/KycSubmissionForm.tsx
+++ b/frontend/src/components/KycSubmissionForm.tsx
@@ -13,6 +13,13 @@ import {
 const STEPS: KycStep[] = ["personal", "address", "documents", "review"];
 const TOTAL_STEPS = STEPS.length;
 
+const STEP_LABEL_KEYS: Record<KycStep, string> = {
+  personal: "personalInfo",
+  address: "addressInfo",
+  documents: "documents",
+  review: "review",
+};
+
 const stepVariants: Variants = {
   enter: (dir: number) => ({
     x: dir > 0 ? 48 : -48,
@@ -101,8 +108,9 @@ function KycSubmissionForm() {
       setDirection(1);
       dispatch({ type: "SET_STEP", step: STEPS[stepIndex + 1]! });
       setStepErrors({});
+      const nextStep = STEPS[stepIndex + 1]!;
       setAnnouncement(
-        `${t("step") || "Step"} ${stepIndex + 2} ${t("of") || "of"} ${TOTAL_STEPS}`,
+        `${t("step") || "Step"} ${stepIndex + 2} ${t("of") || "of"} ${TOTAL_STEPS}: ${t(STEP_LABEL_KEYS[nextStep]) || nextStep}`,
       );
     }
   }, [validateCurrentStep, stepIndex, t]);
@@ -220,7 +228,7 @@ function KycSubmissionForm() {
           aria-valuenow={stepIndex + 1}
           aria-valuemin={1}
           aria-valuemax={TOTAL_STEPS}
-          aria-label={`${t("step") || "Step"} ${stepIndex + 1} ${t("of") || "of"} ${TOTAL_STEPS}`}
+          aria-label={`${t("step") || "Step"} ${stepIndex + 1} ${t("of") || "of"} ${TOTAL_STEPS}: ${t(STEP_LABEL_KEYS[state.currentStep]) || state.currentStep}`}
           className="space-y-2"
         >
           <div className="flex justify-between text-xs text-pluto-600">
@@ -233,6 +241,7 @@ function KycSubmissionForm() {
               <div
                 key={s}
                 role="listitem"
+                aria-label={`${t(STEP_LABEL_KEYS[s]) || s} – ${i < stepIndex ? "completed" : i === stepIndex ? "current" : "upcoming"}`}
                 aria-current={i === stepIndex ? "step" : undefined}
                 className={`h-2 flex-1 rounded-full transition-colors duration-300 ${
                   i <= stepIndex ? "bg-pluto-600" : "bg-pluto-100"
@@ -547,6 +556,7 @@ function KycSubmissionForm() {
             type="button"
             onClick={goBack}
             disabled={stepIndex === 0}
+            aria-label={stepIndex > 0 ? `${t("back")} to ${t(STEP_LABEL_KEYS[STEPS[stepIndex - 1]!]) || STEPS[stepIndex - 1]}` : t("back")}
             className="flex-1 rounded-xl border border-pluto-200 bg-white px-6 py-3 font-semibold text-pluto-900 hover:bg-pluto-50 focus:outline-none focus:ring-2 focus:ring-pluto-400 disabled:opacity-40 disabled:cursor-not-allowed"
           >
             {t("back")}
@@ -556,6 +566,7 @@ function KycSubmissionForm() {
             <button
               type="button"
               onClick={goNext}
+              aria-label={`${t("next")}: ${t(STEP_LABEL_KEYS[STEPS[stepIndex + 1]!]) || STEPS[stepIndex + 1]}`}
               className="flex-1 rounded-xl bg-pluto-600 px-6 py-3 font-semibold text-white hover:bg-pluto-700 focus:outline-none focus:ring-2 focus:ring-pluto-400"
             >
               {t("next")}


### PR DESCRIPTION
 (#963 #964 #965 #966)

 - Add unit tests for KYC Submission Form:
- Tests for step listitem aria-labels (name + status)
- Tests for progressbar aria-label including step name
- Tests for back/next button descriptive aria-labels
- Tests for validation error message text and aria-describedby linkage
- Tests for error clearing after valid navigation
- Tests for idBack and selfie file upload acceptance
- Tests for idType select and idNumber field updates
- Tests for review step dash rendering on empty optional fields
- Tests for submission error alert rendering
 Improve screen reader support for KYC Submission Form:
- Added STEP_LABEL_KEYS map to resolve step translation keys consistently
- Step progress listitems now have aria-label with step name and status (completed/current/upcoming)
- Progressbar aria-label now includes the current step name for better context
- Navigation announcement now names the destination step, not just the step number
- Back button aria-label names the step it returns to
- Next button aria-label names the step it advances to

closes #963 
closes #964
closes #965
closes #966 