### PR TITLE
feat(frontend): screen reader support & optimistic updates for Balance Sync; state refactor & framer-motion for Onboarding Tracker

### DIFF
--- a/frontend/src/components/RealTimeBalanceSync.tsx
+++ b/frontend/src/components/RealTimeBalanceSync.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import React, { useId } from "react";
+import { useBalanceSync } from "@/hooks/useBalanceSync";
+
+interface RealTimeBalanceSyncProps {
+  merchantId?: string | null;
+  apiKey?: string | null;
+  address?: string | null;
+  horizonUrl?: string;
+  pollingInterval?: number;
+  className?: string;
+}
+
+/**
+ * RealTimeBalanceSync
+ *
+ * Displays live Stellar account balances with:
+ * - Polling + optimistic update support via useBalanceSync (issues #955, #956)
+ * - Full screen-reader accessibility: aria-live region, aria-label, aria-busy,
+ *   role="status", and descriptive per-balance labels (issue #955)
+ */
+export function RealTimeBalanceSync({
+  merchantId,
+  apiKey,
+  address,
+  horizonUrl,
+  pollingInterval = 30000,
+  className = "",
+}: RealTimeBalanceSyncProps) {
+  const liveId = useId();
+
+  const {
+    balances,
+    isLoading,
+    lastUpdated,
+    error,
+    refresh,
+    liveRegionText,
+    ariaLabel,
+  } = useBalanceSync(merchantId, apiKey, {
+    address,
+    horizonUrl,
+    pollingInterval,
+    enabled: true,
+  });
+
+  return (
+    <section
+      className={`rounded-2xl border border-gray-200 bg-white p-4 shadow-sm ${className}`}
+      aria-label={ariaLabel}
+      aria-busy={isLoading}
+    >
+      {/* Hidden live region — announced to screen readers on every update (issue #955) */}
+      <div
+        id={liveId}
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {liveRegionText}
+      </div>
+
+      {/* Header */}
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-gray-800">
+          Real-time Balances
+        </h2>
+        <button
+          onClick={refresh}
+          disabled={isLoading}
+          aria-label="Refresh balances"
+          aria-describedby={liveId}
+          className="rounded-md px-2 py-1 text-xs text-blue-600 hover:bg-blue-50 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-400"
+        >
+          {isLoading ? "Syncing…" : "Refresh"}
+        </button>
+      </div>
+
+      {/* Error state */}
+      {error && (
+        <p role="alert" className="mb-2 text-xs text-red-600">
+          {error}
+        </p>
+      )}
+
+      {/* Balance list */}
+      {balances.length === 0 && !isLoading ? (
+        <p className="text-xs text-gray-500" aria-live="polite">
+          No balances available.
+        </p>
+      ) : (
+        <ul
+          role="list"
+          aria-label="Account balances"
+          className="divide-y divide-gray-100"
+        >
+          {balances.map((b) => (
+            <li
+              key={b.code}
+              className="flex items-center justify-between py-2"
+              // Each item is individually labelled for screen readers (issue #955)
+              aria-label={`${b.code} balance: ${b.balance}`}
+            >
+              <span className="text-sm font-medium text-gray-700">{b.code}</span>
+              <span className="text-sm tabular-nums text-gray-900">
+                {parseFloat(b.balance).toLocaleString(undefined, {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 7,
+                })}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* Last updated — hidden from visual but readable by AT */}
+      {lastUpdated && (
+        <p className="mt-3 text-xs text-gray-400">
+          <span aria-hidden="true">Updated </span>
+          <time dateTime={lastUpdated.toISOString()}>
+            {lastUpdated.toLocaleTimeString()}
+          </time>
+        </p>
+      )}
+    </section>
+  );
+}
+
+export default RealTimeBalanceSync;

--- a/frontend/src/hooks/useBalanceSync.test.ts
+++ b/frontend/src/hooks/useBalanceSync.test.ts
@@ -1,6 +1,57 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
-import { useBalanceSync } from "./useBalanceSync";
+import {
+  useBalanceSync,
+  balanceSyncReducer,
+  initialBalanceSyncState,
+} from "./useBalanceSync";
+
+// ─── Pure reducer tests (no hook setup needed) ────────────────────────────────
+
+describe("balanceSyncReducer", () => {
+  it("FETCH_START sets isLoading and clears error", () => {
+    const s = balanceSyncReducer(
+      { ...initialBalanceSyncState, error: "prev error" },
+      { type: "FETCH_START" },
+    );
+    expect(s.isLoading).toBe(true);
+    expect(s.error).toBeNull();
+  });
+
+  it("FETCH_SUCCESS stores balances and clears optimisticBalances", () => {
+    const withOptimistic = balanceSyncReducer(
+      initialBalanceSyncState,
+      { type: "OPTIMISTIC_UPDATE", code: "XLM", balance: "5" },
+    );
+    const at = new Date();
+    const s = balanceSyncReducer(withOptimistic, {
+      type: "FETCH_SUCCESS",
+      balances: [{ code: "XLM", balance: "10" }],
+      at,
+    });
+    expect(s.balances).toEqual([{ code: "XLM", balance: "10" }]);
+    expect(s.optimisticBalances).toEqual({});
+    expect(s.lastUpdated).toBe(at);
+  });
+
+  it("OPTIMISTIC_UPDATE stores the override without touching balances", () => {
+    const s = balanceSyncReducer(
+      initialBalanceSyncState,
+      { type: "OPTIMISTIC_UPDATE", code: "USDC", balance: "50" },
+    );
+    expect(s.optimisticBalances).toEqual({ USDC: "50" });
+    expect(s.balances).toHaveLength(0);
+  });
+
+  it("FETCH_ERROR stores the message and clears loading", () => {
+    const loading = balanceSyncReducer(initialBalanceSyncState, { type: "FETCH_START" });
+    const s = balanceSyncReducer(loading, { type: "FETCH_ERROR", error: "oops" });
+    expect(s.isLoading).toBe(false);
+    expect(s.error).toBe("oops");
+  });
+});
+
+// ─── Hook integration tests ───────────────────────────────────────────────────
 
 describe("useBalanceSync", () => {
   beforeEach(() => {

--- a/frontend/src/hooks/useBalanceSync.ts
+++ b/frontend/src/hooks/useBalanceSync.ts
@@ -1,6 +1,6 @@
 import { useEffect, useReducer, useCallback, useRef } from "react";
 
-interface Balance {
+export interface Balance {
   code: string;
   balance: string;
 }
@@ -13,29 +13,33 @@ interface UseBalanceSyncOptions {
   horizonUrl?: string;
 }
 
-interface BalanceSyncState {
+export interface BalanceSyncState {
   balances: Balance[];
   isLoading: boolean;
   lastUpdated: Date | null;
   error: string | null;
+  /** Balance values that were set optimistically before the next poll confirms them. */
+  optimisticBalances: Record<string, string>;
 }
 
-type BalanceSyncAction =
+export type BalanceSyncAction =
   | { type: "FETCH_START" }
   | { type: "FETCH_SUCCESS"; balances: Balance[]; at: Date }
-  | { type: "FETCH_ERROR"; error: string };
+  | { type: "FETCH_ERROR"; error: string }
+  | { type: "OPTIMISTIC_UPDATE"; code: string; balance: string };
 
-const initialState: BalanceSyncState = {
+export const initialBalanceSyncState: BalanceSyncState = {
   balances: [],
   isLoading: false,
   lastUpdated: null,
   error: null,
+  optimisticBalances: {},
 };
 
 // Consolidating the related pieces of state into a reducer keeps the
 // fetch lifecycle (start → success → error) explicit and prevents the
 // inconsistent intermediate renders that separate setState calls can cause.
-function balanceSyncReducer(
+export function balanceSyncReducer(
   state: BalanceSyncState,
   action: BalanceSyncAction,
 ): BalanceSyncState {
@@ -44,42 +48,76 @@ function balanceSyncReducer(
       return { ...state, isLoading: true, error: null };
     case "FETCH_SUCCESS":
       return {
+        ...state,
         balances: action.balances,
         isLoading: false,
         lastUpdated: action.at,
         error: null,
+        // Clear optimistic overrides once the server value arrives
+        optimisticBalances: {},
       };
     case "FETCH_ERROR":
       return { ...state, isLoading: false, error: action.error };
+    case "OPTIMISTIC_UPDATE":
+      return {
+        ...state,
+        optimisticBalances: {
+          ...state.optimisticBalances,
+          [action.code]: action.balance,
+        },
+      };
     default:
       return state;
   }
 }
 
 /**
- * Hook for real-time balance synchronization with polling and race condition prevention.
+ * Merge confirmed balances with any pending optimistic overrides so callers
+ * always see a consistent view without waiting for the next poll.
+ */
+function applyOptimisticOverrides(
+  balances: Balance[],
+  optimistic: Record<string, string>,
+): Balance[] {
+  if (Object.keys(optimistic).length === 0) return balances;
+  const merged = balances.map((b) =>
+    b.code in optimistic ? { ...b, balance: optimistic[b.code] } : b,
+  );
+  for (const [code, balance] of Object.entries(optimistic)) {
+    if (!merged.find((b) => b.code === code)) {
+      merged.push({ code, balance });
+    }
+  }
+  return merged;
+}
+
+/**
+ * Hook for real-time balance synchronization with polling, race condition
+ * prevention, and optimistic updates (issue #956).
+ *
+ * Screen-reader-ready: returns `ariaLabel` and `liveRegionText` for callers
+ * to wire up accessible live regions (issue #955).
  */
 export function useBalanceSync(
   merchantId: string | null | undefined,
   apiKey: string | null | undefined,
-  options: UseBalanceSyncOptions = {}
+  options: UseBalanceSyncOptions = {},
 ) {
   const {
     pollingInterval = 30000,
     onUpdate,
     enabled = true,
     address = null,
-    horizonUrl = "https://horizon-testnet.stellar.org"
+    horizonUrl = "https://horizon-testnet.stellar.org",
   } = options;
-  const [state, dispatch] = useReducer(balanceSyncReducer, initialState);
-  const { balances, isLoading, lastUpdated, error } = state;
+
+  const [state, dispatch] = useReducer(balanceSyncReducer, initialBalanceSyncState);
   const abortControllerRef = useRef<AbortController | null>(null);
 
   const fetchBalances = useCallback(async () => {
     if (!enabled) return;
     if (!address && (!merchantId || !apiKey)) return;
 
-    // Cancel previous request to prevent race conditions
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
     }
@@ -90,7 +128,6 @@ export function useBalanceSync(
       let newBalances: Balance[] = [];
 
       if (address) {
-        // Fetch from Horizon directly if address is provided
         const response = await fetch(`${horizonUrl}/accounts/${address}`, {
           signal: abortControllerRef.current.signal,
         });
@@ -101,17 +138,12 @@ export function useBalanceSync(
           balance: b.balance,
         }));
       } else {
-        // Fetch from merchant API
         const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
         const response = await fetch(`${apiUrl}/api/merchant/balances`, {
-          headers: {
-            "x-api-key": apiKey!,
-          },
+          headers: { "x-api-key": apiKey! },
           signal: abortControllerRef.current.signal,
         });
-
         if (!response.ok) throw new Error("Failed to fetch balances from API");
-
         const data = await response.json();
         newBalances = (data.balances || []).map((b: any) => ({
           code: b.asset || b.code,
@@ -130,17 +162,12 @@ export function useBalanceSync(
   }, [merchantId, apiKey, enabled, onUpdate, address, horizonUrl]);
 
   /**
-   * Optimistically set a balance locally so the UI reflects a just-submitted
-   * change immediately; the next poll reconciles it with the authoritative value.
+   * Optimistically update a single balance (issue #956).
+   * The value is shown immediately; the next poll from the server clears the
+   * override and replaces it with the authoritative value.
    */
   const applyOptimistic = useCallback((code: string, balance: string) => {
-    setBalances((prev) => {
-      const index = prev.findIndex((b) => b.code === code);
-      if (index === -1) return [...prev, { code, balance }];
-      const next = [...prev];
-      next[index] = { ...next[index], balance };
-      return next;
-    });
+    dispatch({ type: "OPTIMISTIC_UPDATE", code, balance });
   }, []);
 
   useEffect(() => {
@@ -150,20 +177,38 @@ export function useBalanceSync(
       const interval = setInterval(fetchBalances, pollingInterval);
       return () => {
         clearInterval(interval);
-        if (abortControllerRef.current) {
-          abortControllerRef.current.abort();
-        }
+        abortControllerRef.current?.abort();
       };
     }
   }, [fetchBalances, enabled, pollingInterval]);
 
+  const visibleBalances = applyOptimisticOverrides(
+    state.balances,
+    state.optimisticBalances,
+  );
+
+  // Derive an accessible description for live regions (issue #955)
+  const liveRegionText = state.isLoading
+    ? "Syncing balances…"
+    : state.error
+      ? `Balance sync error: ${state.error}`
+      : state.lastUpdated
+        ? `Balances updated at ${state.lastUpdated.toLocaleTimeString()}.`
+        : "";
+
   return {
-    balances,
-    isLoading,
-    lastUpdated,
-    error,
+    balances: visibleBalances,
+    isLoading: state.isLoading,
+    lastUpdated: state.lastUpdated,
+    error: state.error,
     refresh: fetchBalances,
     applyOptimistic,
-    isStale: lastUpdated ? Date.now() - lastUpdated.getTime() > pollingInterval * 2 : true,
+    isStale: state.lastUpdated
+      ? Date.now() - state.lastUpdated.getTime() > pollingInterval * 2
+      : true,
+    /** Aria-label for the balance region — pass to aria-label on the wrapper. */
+    ariaLabel: "Real-time balance information",
+    /** Text to place in an aria-live region so screen readers announce updates. */
+    liveRegionText,
   };
 }


### PR DESCRIPTION
## Summary

- **#955** — Added `RealTimeBalanceSync` component with full a11y: `aria-live` region, `role="status"`, `aria-busy`, `aria-label` on the wrapper, and per-balance `aria-label`. `useBalanceSync` now returns `liveRegionText` and `ariaLabel` for callers to wire up accessible announcements.
- **#956** — Replaced multiple `useState` calls in `useBalanceSync` with a `useReducer` + `OPTIMISTIC_UPDATE` action. `applyOptimistic(code, balance)` reflects changes immediately; optimistic overrides are cleared when the next successful server poll arrives.
- **#957** — Extracted `onboardingReducer` and `createInitialOnboardingState` into a standalone `onboarding-reducer.ts` module with pure unit tests in `onboarding-reducer.test.ts`. `OnboardingProgressTracker` imports from that module.
- **#958** — `OnboardingProgressTracker` uses framer-motion for staggered step entrance, progress bar scale animation, spring check-mark pop-in, and slide-up completion banner. Variants respect `prefers-reduced-motion`.

## Test plan

- [ ] `useBalanceSync` reducer tests pass: FETCH_START / FETCH_SUCCESS / FETCH_ERROR / OPTIMISTIC_UPDATE
- [ ] `applyOptimistic` test: balance appears immediately without a network call, overridden on next poll
- [ ] `onboardingReducer` unit tests pass: optimistic → confirm / rollback lifecycle
- [ ] `RealTimeBalanceSync` mounts without errors; aria-live region announces balance updates
- [ ] `OnboardingProgressTracker` animations play on mount; reduced-motion users see fade-only variants
- [ ] Verify no regressions in `SupportPanel` which also consumes `useBalanceSync`

Closes #955
Closes #956
Closes #957
Closes #958