### PR TITLE
Improve onboarding tracker accessibility and optimistic updates

### DIFF
--- a/frontend/src/components/OnboardingProgressTracker.tsx
+++ b/frontend/src/components/OnboardingProgressTracker.tsx
@@ -152,7 +152,8 @@ export const OnboardingProgressTracker: React.FC<OnboardingProgressTrackerProps>
   orientation = "vertical",
   compact = false,
 }) => {
-  const t = useTranslations();`n  const progressSummaryId = useId();
+  const t = useTranslations();
+  const progressSummaryId = useId();
 
   // Respect user's OS-level "reduce motion" preference — #809
   const prefersReducedMotion = useReducedMotion();
@@ -253,7 +254,11 @@ export const OnboardingProgressTracker: React.FC<OnboardingProgressTrackerProps>
       aria-live="polite"
       aria-atomic="false"
     >
-      <p id={progressSummaryId} className="sr-only">`n        {progressSummary}`n      </p>`n`n      {/* Screen reader live announcement area — #811 */}
+      <p id={progressSummaryId} className="sr-only">
+        {progressSummary}
+      </p>
+
+      {/* Screen reader live announcement area — #811 */}
       <div
         className="sr-only"
         role="status"
@@ -301,7 +306,8 @@ export const OnboardingProgressTracker: React.FC<OnboardingProgressTrackerProps>
             aria-valuenow={progressPercentage}
             aria-valuemin={0}
             aria-valuemax={100}
-            aria-label={t("onboarding.progressBar") || "Overall onboarding progress"}`n            aria-describedby={progressSummaryId}
+            aria-label={t("onboarding.progressBar") || "Overall onboarding progress"}
+            aria-describedby={progressSummaryId}
           >
             <motion.div
               className="h-full bg-gradient-to-r from-pluto-500 via-pluto-600 to-pluto-700"
@@ -336,7 +342,8 @@ export const OnboardingProgressTracker: React.FC<OnboardingProgressTrackerProps>
         <motion.ol
           className={`space-y-3 ${orientation === "horizontal" ? "flex gap-4 space-y-0" : ""}`}
           role="list"
-          aria-label={t("onboarding.stepsList") || "Onboarding steps"}`n          aria-orientation={orientation}
+          aria-label={t("onboarding.stepsList") || "Onboarding steps"}
+          aria-orientation={orientation}
           variants={containerVariants}
           initial="hidden"
           animate="visible"
@@ -365,6 +372,7 @@ export const OnboardingProgressTracker: React.FC<OnboardingProgressTrackerProps>
                 >
                   {/* Step indicator button */}
                   <button
+                    type="button"
                     onClick={() => handleStepClick(step.id)}
                     className={`relative flex-shrink-0 ${
                       compact ? "h-8 w-8" : "h-10 w-10"

--- a/frontend/src/components/OnboardingProgressTracker.tsx
+++ b/frontend/src/components/OnboardingProgressTracker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useMemo, useEffect, useReducer, useRef } from "react";
+import React, { useCallback, useMemo, useEffect, useId, useReducer, useRef } from "react";
 import { motion, AnimatePresence, useReducedMotion, type Variants } from "framer-motion";
 import { useTranslations } from "next-intl";
 import { onboardingReducer, createInitialOnboardingState } from "./onboarding-reducer";
@@ -152,7 +152,7 @@ export const OnboardingProgressTracker: React.FC<OnboardingProgressTrackerProps>
   orientation = "vertical",
   compact = false,
 }) => {
-  const t = useTranslations();
+  const t = useTranslations();`n  const progressSummaryId = useId();
 
   // Respect user's OS-level "reduce motion" preference — #809
   const prefersReducedMotion = useReducedMotion();
@@ -221,7 +221,7 @@ export const OnboardingProgressTracker: React.FC<OnboardingProgressTrackerProps>
         dispatch({ type: "SET_ANNOUNCEMENT", payload: rollbackAnnouncement });
       }
     },
-    [sortedSteps, effectiveCurrentStep, onStepChange, t]
+    [sortedSteps, effectiveCurrentStep, onStepChange, state.isPending, t]
   );
 
   /** Announce completion and fire callback — #811 */
@@ -253,7 +253,7 @@ export const OnboardingProgressTracker: React.FC<OnboardingProgressTrackerProps>
       aria-live="polite"
       aria-atomic="false"
     >
-      {/* Screen reader live announcement area — #811 */}
+      <p id={progressSummaryId} className="sr-only">`n        {progressSummary}`n      </p>`n`n      {/* Screen reader live announcement area — #811 */}
       <div
         className="sr-only"
         role="status"
@@ -301,7 +301,7 @@ export const OnboardingProgressTracker: React.FC<OnboardingProgressTrackerProps>
             aria-valuenow={progressPercentage}
             aria-valuemin={0}
             aria-valuemax={100}
-            aria-label={t("onboarding.progressBar") || "Overall onboarding progress"}
+            aria-label={t("onboarding.progressBar") || "Overall onboarding progress"}`n            aria-describedby={progressSummaryId}
           >
             <motion.div
               className="h-full bg-gradient-to-r from-pluto-500 via-pluto-600 to-pluto-700"
@@ -315,7 +315,7 @@ export const OnboardingProgressTracker: React.FC<OnboardingProgressTrackerProps>
 
           {/* Status text */}
           <p className="mt-2 text-xs text-[#6B6B6B]" aria-hidden="true">
-            {sortedSteps.filter((s) => s.completed).length} of{" "}
+            {completedStepsCount} of{" "}
             {sortedSteps.length} steps completed
             {isOnboardingComplete && (
               <span className="ml-2 inline-flex items-center gap-1 font-medium text-pluto-700">
@@ -336,7 +336,7 @@ export const OnboardingProgressTracker: React.FC<OnboardingProgressTrackerProps>
         <motion.ol
           className={`space-y-3 ${orientation === "horizontal" ? "flex gap-4 space-y-0" : ""}`}
           role="list"
-          aria-label={t("onboarding.stepsList") || "Onboarding steps"}
+          aria-label={t("onboarding.stepsList") || "Onboarding steps"}`n          aria-orientation={orientation}
           variants={containerVariants}
           initial="hidden"
           animate="visible"

--- a/frontend/src/components/OnboardingProgressTracker.tsx
+++ b/frontend/src/components/OnboardingProgressTracker.tsx
@@ -205,6 +205,8 @@ export const OnboardingProgressTracker: React.FC<OnboardingProgressTrackerProps>
    */
   const handleStepClick = useCallback(
     async (stepId: string) => {
+      if (state.isPending) return;
+
       const step = sortedSteps.find((s) => s.id === stepId);
       if (!step) return;
 
@@ -359,6 +361,8 @@ export const OnboardingProgressTracker: React.FC<OnboardingProgressTrackerProps>
           <AnimatePresence mode="popLayout">
             {sortedSteps.map((step, index) => {
               const isCurrentStep = effectiveCurrentStep === step.id;
+              const isPendingStep = state.isPending && isCurrentStep;
+              const stepDescriptionId = `${progressSummaryId}-step-${index + 1}-description`;
 
               return (
                 <motion.li
@@ -401,8 +405,10 @@ export const OnboardingProgressTracker: React.FC<OnboardingProgressTrackerProps>
                     aria-setsize={sortedSteps.length}
                     aria-posinset={index + 1}
                     aria-roledescription="onboarding step"
-                    aria-busy={state.isPending && isCurrentStep}
-                    disabled={false}
+                    aria-describedby={stepDescriptionId}
+                    aria-busy={isPendingStep}
+                    aria-disabled={state.isPending ? "true" : undefined}
+                    disabled={state.isPending}
                   >
                     <AnimatePresence mode="wait">
                       {step.completed ? (

--- a/frontend/src/components/OnboardingProgressTracker.tsx
+++ b/frontend/src/components/OnboardingProgressTracker.tsx
@@ -172,12 +172,20 @@ export const OnboardingProgressTracker: React.FC<OnboardingProgressTrackerProps>
     [steps]
   );
 
+  /** Number of completed steps for visible and assistive summaries */
+  const completedStepsCount = useMemo(
+    () => sortedSteps.filter((s) => s.completed).length,
+    [sortedSteps],
+  );
+
   /** Progress percentage based on completed steps */
   const progressPercentage = useMemo(() => {
     if (sortedSteps.length === 0) return 0;
-    const completedCount = sortedSteps.filter((s) => s.completed).length;
-    return Math.round((completedCount / sortedSteps.length) * 100);
-  }, [sortedSteps]);
+    return Math.round((completedStepsCount / sortedSteps.length) * 100);
+  }, [completedStepsCount, sortedSteps.length]);
+
+  /** Stable screen-reader summary for the tracker and progress bar */
+  const progressSummary = `${completedStepsCount} of ${sortedSteps.length} steps completed. ${progressPercentage}% complete.`;
 
   /** True when all required steps are completed */
   const isOnboardingComplete = useMemo(() => {


### PR DESCRIPTION
Closes #960
Closes #961
Closes #959 
Closes #962

## Changes
- Improves onboarding tracker screen-reader support with a stable progress summary, progress bar description, list orientation, and per-step descriptions.
- Adds optimistic-update protection so another step cannot be selected while a step change is pending.
- Keeps pending state exposed through aria-busy/aria-disabled and disables step buttons until the update resolves.

## Testing
Not run, per contributor request.