### PR TITLE
fix: improve portfolio chart and transaction filter sidebar

### DIFF
--- a/frontend/src/components/PortfolioChart/PortfolioChart.jsx
+++ b/frontend/src/components/PortfolioChart/PortfolioChart.jsx
@@ -1,9 +1,11 @@
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import React, { useState, useEffect, useMemo, useCallback, useRef, useId } from 'react';
 import './PortfolioChart.css';
 
 // Note: This is a simplified chart component
 // In a real implementation, you might use Recharts, Chart.js, or D3
 // For testing purposes, we'll create a basic SVG-based chart
+
+const RANGE_OPTIONS = ['1M', '3M', '6M', '1Y'];
 
 const PortfolioChart = ({
   data = [],
@@ -26,19 +28,34 @@ const PortfolioChart = ({
   const [activePoint, setActivePoint] = useState(null);
   const [selectedRange, setSelectedRange] = useState('1Y');
   const [isMobile, setIsMobile] = useState(false);
+  // Optimistic update state: true immediately when range changes, cleared when parent sends new data
+  const [isPendingRange, setIsPendingRange] = useState(false);
+
+  const announcementsRef = useRef(null);
+  const isFirstRender = useRef(true);
+  const chartId = useId();
 
   // Check for mobile viewport
   useEffect(() => {
     if (!responsive) return;
-    
+
     const checkMobile = () => {
       setIsMobile(window.innerWidth < 768);
     };
-    
+
     checkMobile();
     window.addEventListener('resize', checkMobile);
     return () => window.removeEventListener('resize', checkMobile);
   }, [responsive]);
+
+  // Reset pending state when parent delivers new data in response to range change
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    setIsPendingRange(false);
+  }, [data]);
 
   // Format currency values
   const formatCurrency = useCallback((value) => {
@@ -66,47 +83,57 @@ const PortfolioChart = ({
   // Calculate chart points for SVG rendering
   const chartPoints = useMemo(() => {
     if (!data || data.length === 0) return [];
-    
-    const width = isMobile ? 300 : 600;
+
+    const w = isMobile ? 300 : 600;
     const height_val = isMobile ? 200 : 300;
     const padding = 40;
-    const chartWidth = width - 2 * padding;
+    const chartWidth = w - 2 * padding;
     const chartHeight = height_val - 2 * padding;
-    
+
     return data.map((point, index) => {
       const x = padding + (index / (data.length - 1)) * chartWidth;
-      const y = padding + chartHeight - 
+      const y = padding + chartHeight -
         ((point.value - minValue) / (maxValue - minValue)) * chartHeight;
       return { x, y, value: point.value, date: point.date, original: point };
     });
   }, [data, minValue, maxValue, isMobile]);
 
+  // Concise text summary of chart data for screen readers
+  const dataSummary = useMemo(() => {
+    if (!data || data.length === 0) return '';
+    const values = data.map(d => d.value);
+    const first = data[0];
+    const last = data[data.length - 1];
+    return `${title}. Range: ${first.date} to ${last.date}. Min: ${formatCurrency(Math.min(...values))}, Max: ${formatCurrency(Math.max(...values))}, Latest: ${formatCurrency(last.value)}.`;
+  }, [data, title, formatCurrency]);
+
   // Handle keyboard navigation
   const handleKeyDown = useCallback((e) => {
     if (!keyboardNavigation || !interactive) return;
-    
-    if (e.key === 'ArrowRight' && activePoint !== null && activePoint < chartPoints.length - 1) {
-      setActivePoint(activePoint + 1);
-      if (announcementRegion) {
-        const announcement = `Data point ${activePoint + 2}: ${formatCurrency(chartPoints[activePoint + 1].value)}`;
-        const liveRegion = document.getElementById('sr-announcements');
-        if (liveRegion) liveRegion.textContent = announcement;
-      }
+
+    let next = activePoint;
+    if (e.key === 'ArrowRight') {
+      if (activePoint === null && chartPoints.length > 0) next = 0;
+      else if (activePoint !== null && activePoint < chartPoints.length - 1) next = activePoint + 1;
     } else if (e.key === 'ArrowLeft' && activePoint !== null && activePoint > 0) {
-      setActivePoint(activePoint - 1);
-      if (announcementRegion) {
-        const announcement = `Data point ${activePoint}: ${formatCurrency(chartPoints[activePoint - 1].value)}`;
-        const liveRegion = document.getElementById('sr-announcements');
-        if (liveRegion) liveRegion.textContent = announcement;
+      next = activePoint - 1;
+    } else {
+      return;
+    }
+
+    if (next !== activePoint) {
+      setActivePoint(next);
+      if (announcementRegion && announcementsRef.current && next !== null) {
+        announcementsRef.current.textContent =
+          `Data point ${next + 1} of ${chartPoints.length}: ${chartPoints[next].date}, ${formatCurrency(chartPoints[next].value)}`;
       }
-    } else if (e.key === 'ArrowRight' && activePoint === null && chartPoints.length > 0) {
-      setActivePoint(0);
     }
   }, [keyboardNavigation, interactive, activePoint, chartPoints, formatCurrency, announcementRegion]);
 
-  // Handle range selection
+  // Handle range selection — set optimistic pending state immediately
   const handleRangeChange = useCallback((range) => {
     setSelectedRange(range);
+    setIsPendingRange(true);
     if (onRangeChange) {
       onRangeChange(range);
     }
@@ -141,58 +168,72 @@ const PortfolioChart = ({
   }
 
   return (
-    <div 
+    <div
       className={`portfolio-chart ${isMobile ? 'mobile-view' : 'desktop-view'}`}
       data-testid="portfolio-chart"
       role="figure"
       aria-label={ariaLabel}
+      aria-describedby={`${chartId}-summary`}
     >
+      {/* Visually hidden data summary for screen readers */}
+      <p id={`${chartId}-summary`} className="sr-only">{dataSummary}</p>
+
       {title && <h3 className="chart-title">{title}</h3>}
-      
+
       {/* Date Range Picker */}
       {dateRangePicker && (
-        <div className="range-picker">
-          <button 
-            onClick={() => handleRangeChange('1M')}
-            className={selectedRange === '1M' ? 'active' : ''}
-          >
-            1M
-          </button>
-          <button 
-            onClick={() => handleRangeChange('3M')}
-            className={selectedRange === '3M' ? 'active' : ''}
-          >
-            3M
-          </button>
-          <button 
-            onClick={() => handleRangeChange('6M')}
-            className={selectedRange === '6M' ? 'active' : ''}
-          >
-            6M
-          </button>
-          <button 
-            onClick={() => handleRangeChange('1Y')}
-            className={selectedRange === '1Y' ? 'active' : ''}
-          >
-            1Y
-          </button>
+        <div className="range-picker" role="group" aria-label="Select date range">
+          {RANGE_OPTIONS.map((range) => (
+            <button
+              key={range}
+              onClick={() => handleRangeChange(range)}
+              className={selectedRange === range ? 'active' : ''}
+              aria-pressed={selectedRange === range}
+            >
+              {range}
+            </button>
+          ))}
         </div>
       )}
-      
-      {/* Chart Container */}
-      <div 
+
+      {/* Chart Container — keyboard-focusable for arrow-key navigation */}
+      <div
         className="chart-container"
         data-testid="chart-container"
-        style={{ height: isMobile ? '300px' : `${height}px` }}
+        style={{
+          height: isMobile ? '300px' : `${height}px`,
+          opacity: isPendingRange ? 0.6 : 1,
+          transition: 'opacity 0.2s ease',
+        }}
+        onKeyDown={handleKeyDown}
+        tabIndex={keyboardNavigation ? 0 : -1}
+        aria-label={keyboardNavigation ? 'Use left and right arrow keys to navigate data points' : undefined}
+        aria-busy={isPendingRange}
       >
-        <svg 
-          width={width} 
+        {/* Pending overlay shown while parent fetches new range data */}
+        {isPendingRange && (
+          <div
+            aria-hidden="true"
+            style={{
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              pointerEvents: 'none',
+              zIndex: 1,
+            }}
+          >
+            <div className="loading-spinner" style={{ width: 24, height: 24 }} />
+          </div>
+        )}
+
+        {/* SVG is aria-hidden; the parent figure + summary provide the accessible label */}
+        <svg
+          width={width}
           height={isMobile ? 300 : height}
           viewBox={`0 0 ${isMobile ? 400 : 800} ${isMobile ? 300 : height}`}
-          onKeyDown={handleKeyDown}
-          tabIndex={keyboardNavigation ? 0 : -1}
-          role="img"
-          aria-label={ariaLabel}
+          aria-hidden="true"
         >
           {/* Grid lines */}
           <g className="grid-lines">
@@ -208,7 +249,7 @@ const PortfolioChart = ({
               />
             ))}
           </g>
-          
+
           {/* Chart line */}
           <polyline
             data-testid="chart-line"
@@ -217,7 +258,7 @@ const PortfolioChart = ({
             stroke="#4CAF50"
             strokeWidth="3"
           />
-          
+
           {/* Data points */}
           {chartPoints.map((point, index) => (
             <circle
@@ -232,7 +273,7 @@ const PortfolioChart = ({
               onClick={() => onDataPointClick && onDataPointClick(point.original)}
             />
           ))}
-          
+
           {/* Labels */}
           <g className="labels">
             {chartPoints.map((point, index) => (
@@ -249,7 +290,7 @@ const PortfolioChart = ({
           </g>
         </svg>
       </div>
-      
+
       {/* Legend */}
       {showLegend && (
         <div className="chart-legend" data-testid="chart-legend">
@@ -259,23 +300,24 @@ const PortfolioChart = ({
           </div>
         </div>
       )}
-      
-      {/* Screen reader announcements */}
+
+      {/* Screen reader announcements — uses ref to avoid global ID conflicts */}
       {announcementRegion && (
-        <div 
-          id="sr-announcements"
+        <div
+          ref={announcementsRef}
           data-testid="sr-announcements"
           className="sr-only"
           aria-live="polite"
           aria-atomic="true"
-        ></div>
+        />
       )}
-      
+
       {/* Tooltip for active point */}
       {activePoint !== null && chartPoints[activePoint] && interactive && (
-        <div 
+        <div
           className="chart-tooltip"
           data-testid="chart-tooltip"
+          role="tooltip"
           style={{
             position: 'absolute',
             left: `${chartPoints[activePoint].x}px`,

--- a/frontend/src/components/TransactionFilterSidebar.tsx
+++ b/frontend/src/components/TransactionFilterSidebar.tsx
@@ -47,6 +47,18 @@ const STATUS_OPTIONS = [
 
 const ASSET_OPTIONS = ["all", "XLM", "USDC"] as const;
 
+// ─── Animation variants ───────────────────────────────────────────────────────
+
+const filterListVariants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.06 } },
+};
+
+const filterItemVariants = {
+  hidden: { opacity: 0, y: 8 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.2, ease: "easeOut" } },
+};
+
 // ─── Small reusable pieces ───────────────────────────────────────────────────
 
 /** Spinning ring shown while a filter is syncing to the URL. */
@@ -57,7 +69,6 @@ function SyncSpinner({ label = "Syncing…" }: { label?: string }) {
       aria-label={label}
       className="inline-flex items-center gap-1 text-[10px] font-semibold text-[var(--pluto-500)]"
     >
-      {/* Accessible spinner */}
       <svg
         className="h-3 w-3 animate-spin"
         viewBox="0 0 24 24"
@@ -136,6 +147,444 @@ function SyncProgressBar({ visible }: { visible: boolean }) {
   );
 }
 
+// ─── FilterContent ───────────────────────────────────────────────────────────
+
+interface FilterContentProps {
+  filters: FilterState;
+  onFilterChange: (key: keyof FilterState, value: string) => void;
+  onClearFilter: (key: keyof FilterState) => void;
+  onClearAll: () => void;
+  hasActiveFilters: boolean;
+  searchSyncPending: boolean;
+  isFilterPending: boolean;
+  anyPending: boolean;
+  activeFilterCount: number;
+  isMobile: boolean;
+  uid: string;
+  onClose?: () => void;
+}
+
+/**
+ * Renders the filter panel content (header, fields, footer).
+ * Extracted so the same markup can be shared between the desktop sticky
+ * panel and the mobile animated drawer without duplication.
+ */
+function FilterContent({
+  filters,
+  onFilterChange,
+  onClearFilter,
+  onClearAll,
+  hasActiveFilters,
+  searchSyncPending,
+  isFilterPending,
+  anyPending,
+  activeFilterCount,
+  isMobile,
+  uid,
+  onClose,
+}: FilterContentProps) {
+  const suffix = isMobile ? `-${uid}-mobile` : `-${uid}-desktop`;
+
+  return (
+    <div className="relative flex h-full flex-col rounded-2xl bg-white p-6 shadow-xl border border-[#E8E8E8]">
+      {/* ── Sync progress bar ── */}
+      <SyncProgressBar visible={anyPending} />
+
+      {/* ── Header ── */}
+      <div className="mb-8 flex items-center justify-between">
+        <div className="flex items-center">
+          <h2 className="text-xl font-bold text-[#0A0A0A]">Filters</h2>
+          {/* Animated active-filter count badge */}
+          <AnimatePresence mode="wait">
+            {activeFilterCount > 0 && (
+              <motion.span
+                key="count-badge"
+                initial={{ opacity: 0, scale: 0.6 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.6 }}
+                transition={{ duration: 0.15 }}
+                className="ml-2 rounded-full bg-[var(--pluto-500)] px-2 py-0.5 text-[10px] font-bold text-white"
+                aria-hidden="true"
+              >
+                {activeFilterCount}
+              </motion.span>
+            )}
+          </AnimatePresence>
+          <PendingBadge visible={anyPending} />
+          {/* Screen-reader live region for filter count announcements */}
+          <span
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            className="sr-only"
+          >
+            {activeFilterCount > 0
+              ? `${activeFilterCount} filter${activeFilterCount === 1 ? "" : "s"} active`
+              : ""}
+          </span>
+        </div>
+        {onClose && isMobile && (
+          <button
+            onClick={onClose}
+            className="rounded-full p-2 hover:bg-[#F5F5F5] transition-colors lg:hidden"
+            aria-label="Close filters"
+          >
+            <svg
+              className="h-5 w-5 text-[#6B6B6B]"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        )}
+      </div>
+
+      {/* ── Filter fields — staggered on mount ── */}
+      <motion.div
+        className="flex flex-1 flex-col gap-6 overflow-y-auto pr-1 custom-scrollbar"
+        variants={filterListVariants}
+        initial="hidden"
+        animate="visible"
+      >
+        {/* Search */}
+        <motion.div variants={filterItemVariants} className="flex flex-col gap-2">
+          <div className="flex items-center justify-between">
+            <label
+              htmlFor={`sidebar-search${suffix}`}
+              className="text-[10px] font-bold uppercase tracking-widest text-[#6B6B6B]"
+            >
+              Search
+            </label>
+            <AnimatePresence>
+              {searchSyncPending && (
+                <motion.span
+                  key="search-sync"
+                  initial={{ opacity: 0, x: 4 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: 4 }}
+                  transition={{ duration: 0.15 }}
+                >
+                  <SyncSpinner label="Applying search to results" />
+                </motion.span>
+              )}
+            </AnimatePresence>
+          </div>
+
+          <div className="relative">
+            <input
+              id={`sidebar-search${suffix}`}
+              type="text"
+              value={filters.search}
+              onChange={(e) => onFilterChange("search", e.target.value)}
+              aria-busy={searchSyncPending}
+              aria-describedby={
+                searchSyncPending
+                  ? `sidebar-search-hint${suffix}`
+                  : undefined
+              }
+              placeholder="ID or description…"
+              className={[
+                "w-full rounded-xl border bg-[#F9F9F9] py-2.5 pl-10 pr-9 text-sm text-[#0A0A0A]",
+                "placeholder:text-[#6B6B6B] focus:bg-white focus:outline-none transition-all duration-200",
+                searchSyncPending
+                  ? "border-dashed border-[var(--pluto-400)] focus:border-[var(--pluto-500)]"
+                  : "border-[#E8E8E8] focus:border-[var(--pluto-500)]",
+              ].join(" ")}
+            />
+
+            {/* Search icon */}
+            <svg
+              className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#A0A0A0]"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+              />
+            </svg>
+
+            {/* Clear search button — shown when there's a value */}
+            <AnimatePresence>
+              {filters.search && (
+                <motion.button
+                  key="clear-search"
+                  initial={{ opacity: 0, scale: 0.7 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.7 }}
+                  transition={{ duration: 0.12 }}
+                  type="button"
+                  onClick={() => onClearFilter("search")}
+                  aria-label="Clear search"
+                  className="absolute right-2.5 top-1/2 -translate-y-1/2 rounded-full p-0.5 text-[#A0A0A0] hover:bg-[#F0F0F0] hover:text-[#0A0A0A] transition-colors"
+                >
+                  <svg
+                    className="h-3.5 w-3.5"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2.5}
+                      d="M6 18L18 6M6 6l12 12"
+                    />
+                  </svg>
+                </motion.button>
+              )}
+            </AnimatePresence>
+          </div>
+
+          {/* Accessible hint when debounce is pending */}
+          {searchSyncPending && (
+            <p
+              id={`sidebar-search-hint${suffix}`}
+              className="text-[10px] text-[var(--pluto-500)] font-medium"
+              aria-live="polite"
+            >
+              Applying to results…
+            </p>
+          )}
+        </motion.div>
+
+        {/* Status */}
+        <motion.div variants={filterItemVariants} className="flex flex-col gap-2">
+          <div className="flex items-center justify-between">
+            <label
+              htmlFor={`sidebar-status${suffix}`}
+              className="text-[10px] font-bold uppercase tracking-widest text-[#6B6B6B]"
+            >
+              Status
+            </label>
+            <AnimatePresence>
+              {isFilterPending && filters.status !== "all" && (
+                <motion.span
+                  key="status-sync"
+                  initial={{ opacity: 0, x: 4 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: 4 }}
+                  transition={{ duration: 0.15 }}
+                  aria-hidden="true"
+                >
+                  <SyncSpinner label="Applying status filter" />
+                </motion.span>
+              )}
+            </AnimatePresence>
+          </div>
+
+          <div className="relative">
+            <select
+              id={`sidebar-status${suffix}`}
+              value={filters.status}
+              onChange={(e) => onFilterChange("status", e.target.value)}
+              aria-busy={isFilterPending}
+              className={[
+                "w-full rounded-xl border bg-[#F9F9F9] px-4 py-2.5 text-sm text-[#0A0A0A] appearance-none cursor-pointer",
+                "focus:bg-white focus:outline-none transition-all duration-200",
+                isFilterPending
+                  ? "border-dashed border-[var(--pluto-400)]"
+                  : "border-[#E8E8E8] focus:border-[var(--pluto-500)]",
+              ].join(" ")}
+            >
+              {STATUS_OPTIONS.map((s) => (
+                <option key={s} value={s}>
+                  {s === "all"
+                    ? "All Statuses"
+                    : s.charAt(0).toUpperCase() + s.slice(1)}
+                </option>
+              ))}
+            </select>
+
+            {/* Chevron icon */}
+            <svg
+              className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#A0A0A0]"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 9l-7 7-7-7"
+              />
+            </svg>
+          </div>
+        </motion.div>
+
+        {/* Asset */}
+        <motion.div variants={filterItemVariants} className="flex flex-col gap-2">
+          <p className="text-[10px] font-bold uppercase tracking-widest text-[#6B6B6B]">
+            Asset
+          </p>
+          <div className="flex flex-wrap gap-2" role="group" aria-label="Asset filter">
+            {ASSET_OPTIONS.map((a) => {
+              const isActive = filters.asset === a;
+              return (
+                <motion.button
+                  key={a}
+                  type="button"
+                  onClick={() => onFilterChange("asset", a)}
+                  whileHover={{ scale: 1.04 }}
+                  whileTap={{ scale: 0.93 }}
+                  aria-pressed={isActive}
+                  aria-busy={isFilterPending && isActive}
+                  className={[
+                    "rounded-full px-4 py-1.5 text-xs font-bold uppercase tracking-widest transition-all duration-200",
+                    isActive
+                      ? "bg-[var(--pluto-500)] text-white shadow-md shadow-[var(--pluto-500)]/20"
+                      : "border border-[#E8E8E8] bg-[#F9F9F9] text-[#6B6B6B] hover:border-[var(--pluto-300)] hover:bg-[var(--pluto-50,#f0f4ff)]",
+                    isFilterPending && isActive ? "opacity-70" : "",
+                  ].join(" ")}
+                >
+                  {a === "all" ? "All" : a}
+                  {isFilterPending && isActive && (
+                    <span className="ml-1.5 inline-block" aria-hidden="true">
+                      <SyncSpinner />
+                    </span>
+                  )}
+                </motion.button>
+              );
+            })}
+          </div>
+        </motion.div>
+
+        {/* Date Range */}
+        <motion.div
+          variants={filterItemVariants}
+          className="mt-2 flex flex-col gap-4 border-t border-[#F0F0F0] pt-4"
+        >
+          <p className="text-[10px] font-bold uppercase tracking-widest text-[#6B6B6B]">
+            Date Range
+          </p>
+          <div className="flex flex-col gap-3">
+            {/* From */}
+            <div className="flex flex-col gap-1.5">
+              <div className="flex items-center justify-between">
+                <label
+                  htmlFor={`sidebar-date-from${suffix}`}
+                  className="text-[10px] font-medium text-[#A0A0A0]"
+                >
+                  From
+                </label>
+                <AnimatePresence>
+                  {isFilterPending && filters.dateFrom && (
+                    <motion.span
+                      key="from-sync"
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: 1 }}
+                      exit={{ opacity: 0 }}
+                    >
+                      <SyncSpinner label="Applying date from" />
+                    </motion.span>
+                  )}
+                </AnimatePresence>
+              </div>
+              <input
+                id={`sidebar-date-from${suffix}`}
+                type="date"
+                value={filters.dateFrom}
+                onChange={(e) => onFilterChange("dateFrom", e.target.value)}
+                aria-busy={isFilterPending}
+                className={[
+                  "w-full rounded-xl border bg-[#F9F9F9] px-3 py-2 text-sm text-[#0A0A0A]",
+                  "focus:outline-none [color-scheme:light] transition-all duration-200",
+                  isFilterPending && filters.dateFrom
+                    ? "border-dashed border-[var(--pluto-400)]"
+                    : "border-[#E8E8E8] focus:border-[var(--pluto-500)]",
+                ].join(" ")}
+              />
+            </div>
+
+            {/* To */}
+            <div className="flex flex-col gap-1.5">
+              <div className="flex items-center justify-between">
+                <label
+                  htmlFor={`sidebar-date-to${suffix}`}
+                  className="text-[10px] font-medium text-[#A0A0A0]"
+                >
+                  To
+                </label>
+                <AnimatePresence>
+                  {isFilterPending && filters.dateTo && (
+                    <motion.span
+                      key="to-sync"
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: 1 }}
+                      exit={{ opacity: 0 }}
+                    >
+                      <SyncSpinner label="Applying date to" />
+                    </motion.span>
+                  )}
+                </AnimatePresence>
+              </div>
+              <input
+                id={`sidebar-date-to${suffix}`}
+                type="date"
+                value={filters.dateTo}
+                onChange={(e) => onFilterChange("dateTo", e.target.value)}
+                aria-busy={isFilterPending}
+                className={[
+                  "w-full rounded-xl border bg-[#F9F9F9] px-3 py-2 text-sm text-[#0A0A0A]",
+                  "focus:outline-none [color-scheme:light] transition-all duration-200",
+                  isFilterPending && filters.dateTo
+                    ? "border-dashed border-[var(--pluto-400)]"
+                    : "border-[#E8E8E8] focus:border-[var(--pluto-500)]",
+                ].join(" ")}
+              />
+            </div>
+          </div>
+        </motion.div>
+      </motion.div>
+
+      {/* ── Footer ── */}
+      <div className="mt-8 border-t border-[#F0F0F0] pt-6">
+        <motion.button
+          type="button"
+          onClick={onClearAll}
+          disabled={!hasActiveFilters}
+          whileHover={hasActiveFilters ? { scale: 1.01 } : undefined}
+          whileTap={hasActiveFilters ? { scale: 0.97 } : undefined}
+          aria-label={
+            activeFilterCount > 0
+              ? `Clear all ${activeFilterCount} active filter${activeFilterCount === 1 ? "" : "s"}`
+              : "Clear all filters"
+          }
+          className={[
+            "w-full rounded-xl py-3 text-[10px] font-bold uppercase tracking-widest transition-all duration-200",
+            "bg-[#0A0A0A] text-white hover:bg-[#2A2A2A] active:scale-[0.98]",
+            "disabled:cursor-not-allowed disabled:opacity-20",
+          ].join(" ")}
+        >
+          {anyPending ? (
+            <span className="flex items-center justify-center gap-2">
+              <SyncSpinner label="Clearing filters" />
+              Clearing…
+            </span>
+          ) : (
+            "Clear All Filters"
+          )}
+        </motion.button>
+      </div>
+    </div>
+  );
+}
+
 // ─── Main component ──────────────────────────────────────────────────────────
 
 export default function TransactionFilterSidebar({
@@ -161,391 +610,18 @@ export default function TransactionFilterSidebar({
     filters.dateTo !== "",
   ].filter(Boolean).length;
 
-  const renderContent = (isMobile: boolean) => {
-    const suffix = isMobile ? `-${uid}-mobile` : `-${uid}-desktop`;
-
-    return (
-      <div className="relative flex h-full flex-col rounded-2xl bg-white p-6 shadow-xl border border-[#E8E8E8]">
-        {/* ── Sync progress bar ── */}
-        <SyncProgressBar visible={anyPending} />
-
-        {/* ── Header ── */}
-        <div className="mb-8 flex items-center justify-between">
-          <div className="flex items-center">
-            <h2 className="text-xl font-bold text-[#0A0A0A]">Filters</h2>
-            {/* Optimistic active-filter count badge — updates before URL sync */}
-            {activeFilterCount > 0 && (
-              <span
-                className="ml-2 rounded-full bg-[var(--pluto-500)] px-2 py-0.5 text-[10px] font-bold text-white"
-                aria-hidden="true"
-              >
-                {activeFilterCount}
-              </span>
-            )}
-            <PendingBadge visible={anyPending} />
-            {/* Screen-reader live region for filter count announcements */}
-            <span
-              role="status"
-              aria-live="polite"
-              aria-atomic="true"
-              className="sr-only"
-            >
-              {activeFilterCount > 0
-                ? `${activeFilterCount} filter${activeFilterCount === 1 ? "" : "s"} active`
-                : ""}
-            </span>
-          </div>
-          {onClose && isMobile && (
-            <button
-              onClick={onClose}
-              className="rounded-full p-2 hover:bg-[#F5F5F5] transition-colors lg:hidden"
-              aria-label="Close filters"
-            >
-              <svg
-                className="h-5 w-5 text-[#6B6B6B]"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M6 18L18 6M6 6l12 12"
-                />
-              </svg>
-            </button>
-          )}
-        </div>
-
-        {/* ── Filter fields ── */}
-        <div className="flex flex-1 flex-col gap-6 overflow-y-auto pr-1 custom-scrollbar">
-
-          {/* Search */}
-          <div className="flex flex-col gap-2">
-            <div className="flex items-center justify-between">
-              <label
-                htmlFor={`sidebar-search${suffix}`}
-                className="text-[10px] font-bold uppercase tracking-widest text-[#6B6B6B]"
-              >
-                Search
-              </label>
-              <AnimatePresence>
-                {searchSyncPending && (
-                  <motion.span
-                    key="search-sync"
-                    initial={{ opacity: 0, x: 4 }}
-                    animate={{ opacity: 1, x: 0 }}
-                    exit={{ opacity: 0, x: 4 }}
-                    transition={{ duration: 0.15 }}
-                  >
-                    <SyncSpinner label="Applying search to results" />
-                  </motion.span>
-                )}
-              </AnimatePresence>
-            </div>
-
-            <div className="relative">
-              <input
-                id={`sidebar-search${suffix}`}
-                type="text"
-                value={filters.search}
-                onChange={(e) => onFilterChange("search", e.target.value)}
-                aria-busy={searchSyncPending}
-                aria-describedby={
-                  searchSyncPending
-                    ? `sidebar-search-hint${suffix}`
-                    : undefined
-                }
-                placeholder="ID or description…"
-                className={[
-                  "w-full rounded-xl border bg-[#F9F9F9] py-2.5 pl-10 pr-9 text-sm text-[#0A0A0A]",
-                  "placeholder:text-[#6B6B6B] focus:bg-white focus:outline-none transition-all duration-200",
-                  searchSyncPending
-                    ? "border-dashed border-[var(--pluto-400)] focus:border-[var(--pluto-500)]"
-                    : "border-[#E8E8E8] focus:border-[var(--pluto-500)]",
-                ].join(" ")}
-              />
-
-              {/* Search icon */}
-              <svg
-                className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#A0A0A0]"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-                />
-              </svg>
-
-              {/* Clear search button — shown when there's a value */}
-              <AnimatePresence>
-                {filters.search && (
-                  <motion.button
-                    key="clear-search"
-                    initial={{ opacity: 0, scale: 0.7 }}
-                    animate={{ opacity: 1, scale: 1 }}
-                    exit={{ opacity: 0, scale: 0.7 }}
-                    transition={{ duration: 0.12 }}
-                    type="button"
-                    onClick={() => onClearFilter("search")}
-                    aria-label="Clear search"
-                    className="absolute right-2.5 top-1/2 -translate-y-1/2 rounded-full p-0.5 text-[#A0A0A0] hover:bg-[#F0F0F0] hover:text-[#0A0A0A] transition-colors"
-                  >
-                    <svg
-                      className="h-3.5 w-3.5"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                      aria-hidden="true"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2.5}
-                        d="M6 18L18 6M6 6l12 12"
-                      />
-                    </svg>
-                  </motion.button>
-                )}
-              </AnimatePresence>
-            </div>
-
-            {/* Accessible hint when debounce is pending */}
-            {searchSyncPending && (
-              <p
-                id={`sidebar-search-hint${suffix}`}
-                className="text-[10px] text-[var(--pluto-500)] font-medium"
-                aria-live="polite"
-              >
-                Applying to results…
-              </p>
-            )}
-          </div>
-
-          {/* Status */}
-          <div className="flex flex-col gap-2">
-            <div className="flex items-center justify-between">
-              <label
-                htmlFor={`sidebar-status${suffix}`}
-                className="text-[10px] font-bold uppercase tracking-widest text-[#6B6B6B]"
-              >
-                Status
-              </label>
-              <AnimatePresence>
-                {isFilterPending && filters.status !== "all" && (
-                  <motion.span
-                    key="status-sync"
-                    initial={{ opacity: 0, x: 4 }}
-                    animate={{ opacity: 1, x: 0 }}
-                    exit={{ opacity: 0, x: 4 }}
-                    transition={{ duration: 0.15 }}
-                    aria-hidden="true"
-                  >
-                    <SyncSpinner label="Applying status filter" />
-                  </motion.span>
-                )}
-              </AnimatePresence>
-            </div>
-
-            <div className="relative">
-              <select
-                id={`sidebar-status${suffix}`}
-                value={filters.status}
-                onChange={(e) => onFilterChange("status", e.target.value)}
-                aria-busy={isFilterPending}
-                className={[
-                  "w-full rounded-xl border bg-[#F9F9F9] px-4 py-2.5 text-sm text-[#0A0A0A] appearance-none cursor-pointer",
-                  "focus:bg-white focus:outline-none transition-all duration-200",
-                  isFilterPending
-                    ? "border-dashed border-[var(--pluto-400)]"
-                    : "border-[#E8E8E8] focus:border-[var(--pluto-500)]",
-                ].join(" ")}
-              >
-                {STATUS_OPTIONS.map((s) => (
-                  <option key={s} value={s}>
-                    {s === "all"
-                      ? "All Statuses"
-                      : s.charAt(0).toUpperCase() + s.slice(1)}
-                  </option>
-                ))}
-              </select>
-
-              {/* Chevron icon */}
-              <svg
-                className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#A0A0A0]"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M19 9l-7 7-7-7"
-                />
-              </svg>
-            </div>
-          </div>
-
-          {/* Asset */}
-          <div className="flex flex-col gap-2">
-            <p className="text-[10px] font-bold uppercase tracking-widest text-[#6B6B6B]">
-              Asset
-            </p>
-            <div className="flex flex-wrap gap-2" role="group" aria-label="Asset filter">
-              {ASSET_OPTIONS.map((a) => {
-                const isActive = filters.asset === a;
-                return (
-                  <motion.button
-                    key={a}
-                    type="button"
-                    onClick={() => onFilterChange("asset", a)}
-                    whileTap={{ scale: 0.93 }}
-                    aria-pressed={isActive}
-                    aria-busy={isFilterPending && isActive}
-                    className={[
-                      "rounded-full px-4 py-1.5 text-xs font-bold uppercase tracking-widest transition-all duration-200",
-                      isActive
-                        ? "bg-[var(--pluto-500)] text-white shadow-md shadow-[var(--pluto-500)]/20"
-                        : "border border-[#E8E8E8] bg-[#F9F9F9] text-[#6B6B6B] hover:border-[var(--pluto-300)] hover:bg-[var(--pluto-50,#f0f4ff)]",
-                      isFilterPending && isActive ? "opacity-70" : "",
-                    ].join(" ")}
-                  >
-                    {a === "all" ? "All" : a}
-                    {isFilterPending && isActive && (
-                      <span className="ml-1.5 inline-block" aria-hidden="true">
-                        <SyncSpinner />
-                      </span>
-                    )}
-                  </motion.button>
-                );
-              })}
-            </div>
-          </div>
-
-          {/* Date Range */}
-          <div className="mt-2 flex flex-col gap-4 border-t border-[#F0F0F0] pt-4">
-            <p className="text-[10px] font-bold uppercase tracking-widest text-[#6B6B6B]">
-              Date Range
-            </p>
-            <div className="flex flex-col gap-3">
-              {/* From */}
-              <div className="flex flex-col gap-1.5">
-                <div className="flex items-center justify-between">
-                  <label
-                    htmlFor={`sidebar-date-from${suffix}`}
-                    className="text-[10px] font-medium text-[#A0A0A0]"
-                  >
-                    From
-                  </label>
-                  <AnimatePresence>
-                    {isFilterPending && filters.dateFrom && (
-                      <motion.span
-                        key="from-sync"
-                        initial={{ opacity: 0 }}
-                        animate={{ opacity: 1 }}
-                        exit={{ opacity: 0 }}
-                      >
-                        <SyncSpinner label="Applying date from" />
-                      </motion.span>
-                    )}
-                  </AnimatePresence>
-                </div>
-                <input
-                  id={`sidebar-date-from${suffix}`}
-                  type="date"
-                  value={filters.dateFrom}
-                  onChange={(e) => onFilterChange("dateFrom", e.target.value)}
-                  aria-busy={isFilterPending}
-                  className={[
-                    "w-full rounded-xl border bg-[#F9F9F9] px-3 py-2 text-sm text-[#0A0A0A]",
-                    "focus:outline-none [color-scheme:light] transition-all duration-200",
-                    isFilterPending && filters.dateFrom
-                      ? "border-dashed border-[var(--pluto-400)]"
-                      : "border-[#E8E8E8] focus:border-[var(--pluto-500)]",
-                  ].join(" ")}
-                />
-              </div>
-
-              {/* To */}
-              <div className="flex flex-col gap-1.5">
-                <div className="flex items-center justify-between">
-                  <label
-                    htmlFor={`sidebar-date-to${suffix}`}
-                    className="text-[10px] font-medium text-[#A0A0A0]"
-                  >
-                    To
-                  </label>
-                  <AnimatePresence>
-                    {isFilterPending && filters.dateTo && (
-                      <motion.span
-                        key="to-sync"
-                        initial={{ opacity: 0 }}
-                        animate={{ opacity: 1 }}
-                        exit={{ opacity: 0 }}
-                      >
-                        <SyncSpinner label="Applying date to" />
-                      </motion.span>
-                    )}
-                  </AnimatePresence>
-                </div>
-                <input
-                  id={`sidebar-date-to${suffix}`}
-                  type="date"
-                  value={filters.dateTo}
-                  onChange={(e) => onFilterChange("dateTo", e.target.value)}
-                  aria-busy={isFilterPending}
-                  className={[
-                    "w-full rounded-xl border bg-[#F9F9F9] px-3 py-2 text-sm text-[#0A0A0A]",
-                    "focus:outline-none [color-scheme:light] transition-all duration-200",
-                    isFilterPending && filters.dateTo
-                      ? "border-dashed border-[var(--pluto-400)]"
-                      : "border-[#E8E8E8] focus:border-[var(--pluto-500)]",
-                  ].join(" ")}
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {/* ── Footer ── */}
-        <div className="mt-8 border-t border-[#F0F0F0] pt-6">
-          <motion.button
-            type="button"
-            onClick={onClearAll}
-            disabled={!hasActiveFilters}
-            whileTap={hasActiveFilters ? { scale: 0.97 } : undefined}
-            aria-label={
-              activeFilterCount > 0
-                ? `Clear all ${activeFilterCount} active filter${activeFilterCount === 1 ? "" : "s"}`
-                : "Clear all filters"
-            }
-            className={[
-              "w-full rounded-xl py-3 text-[10px] font-bold uppercase tracking-widest transition-all duration-200",
-              "bg-[#0A0A0A] text-white hover:bg-[#2A2A2A] active:scale-[0.98]",
-              "disabled:cursor-not-allowed disabled:opacity-20",
-            ].join(" ")}
-          >
-            {anyPending ? (
-              <span className="flex items-center justify-center gap-2">
-                <SyncSpinner label="Clearing filters" />
-                Clearing…
-              </span>
-            ) : (
-              "Clear All Filters"
-            )}
-          </motion.button>
-        </div>
-      </div>
-    );
+  const sharedProps = {
+    filters,
+    onFilterChange,
+    onClearFilter,
+    onClearAll,
+    hasActiveFilters,
+    searchSyncPending,
+    isFilterPending,
+    anyPending,
+    activeFilterCount,
+    uid,
+    onClose,
   };
 
   return (
@@ -556,7 +632,7 @@ export default function TransactionFilterSidebar({
         role="complementary"
         aria-label="Transaction filters"
       >
-        {renderContent(false)}
+        <FilterContent {...sharedProps} isMobile={false} />
       </div>
 
       {/* Mobile: animated drawer */}
@@ -584,7 +660,7 @@ export default function TransactionFilterSidebar({
               aria-modal="true"
               aria-label="Filter sidebar"
             >
-              {renderContent(true)}
+              <FilterContent {...sharedProps} isMobile={true} />
             </motion.aside>
           </>
         )}


### PR DESCRIPTION
## Summary

  Resolves four frontend UX enhancement issues for `TransactionFilterSidebar` and `PortfolioChart Widget`.

  ## Changes

  ### TransactionFilterSidebar
  - **Refactor state logic (#937):** Extracted inner `renderContent` function into a dedicated `FilterContent`
  component with explicit `FilterContentProps` interface. Desktop and mobile panels now share the same component
  rather than duplicated inline logic.
  - **Framer-motion animations (#938):** Added staggered entry animations for all four filter sections on mount
  (`filterListVariants` / `filterItemVariants`). Active-filter count badge now animates in/out with `AnimatePresence`.
  Asset buttons gain `whileHover` scale. Clear All button gains `whileHover` scale.

  ### PortfolioChart Widget
  - **Optimistic updates (#936):** Added `isPendingRange` state that turns `true` immediately on range button click
  and resets when parent delivers new `data`. While pending, the chart dims to 60% opacity with a loading spinner
  overlay and `aria-busy` on the container.
  - **Screen reader support (#935):** Added `aria-pressed` to date range picker buttons. Replaced global
  `id="sr-announcements"` + `document.getElementById` with a `useRef` to prevent ID conflicts when multiple charts
  render. Added a visually-hidden data summary paragraph (`aria-describedby` on the figure). SVG marked
  `aria-hidden="true"` (outer figure provides the label); keyboard focus moved to the chart container with descriptive
  `aria-label`.

  ## Testing
  - All existing `data-testid` attributes preserved — no test selectors changed
  - `role="status"`, `role="alert"`, `role="figure"`, `role="tooltip"` maintained
  - Screen reader summary text verified for min/max/latest/date-range content
  - Mobile drawer spring animation and backdrop unchanged

  Closes #935, Closes #936, Closes #937, Closes #938