### PR TITLE
feat(backend): harden Admin Dashboard Service — rate limiting, signature verification, SQL optimization, error recovery

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -11,7 +11,7 @@ import { createSwaggerSpec } from "./swagger.js";
 
 import createPaymentsRouter from "./routes/payments.js";
 import createMerchantsRouter from "./routes/merchants.js";
-import metricsRouter from "./routes/metrics.js";
+import createMetricsRouter from "./routes/metrics.js";
 import webhooksRouter from "./routes/webhooks.js";
 import prometheusRouter from "./routes/prometheus.js";
 import sep0001Router from "./routes/sep0001.js";
@@ -35,6 +35,7 @@ import {
   createMerchantRegistrationRateLimit,
   createSep10ChallengeRateLimit,
   createSep10VerifyRateLimit,
+  createDashboardMetricsRateLimit,
 } from "./lib/rate-limit.js";
 import { versionDeprecationMiddleware } from "./lib/version-deprecation.js";
 
@@ -262,6 +263,14 @@ export async function createApp({ redisClient }) {
     sep10ChallengeRateLimit: createSep10ChallengeRateLimit({ store: sep10RateLimitStore }),
     sep10VerifyRateLimit: createSep10VerifyRateLimit({ store: sep10RateLimitStore }),
   });
+
+  const dashboardMetricsRateLimit = createDashboardMetricsRateLimit({
+    store: redisAvailable
+      ? createRedisRateLimitStore({ client: redisClient, prefix: "rl:dashboard:" })
+      : undefined,
+  });
+
+  const metricsRouter = createMetricsRouter({ dashboardMetricsRateLimit });
 
   // x402 pay-per-request on payment creation endpoints (custom middleware flow)
   const x402Provider = process.env.X402_PROVIDER_PUBLIC_KEY;

--- a/backend/src/lib/rate-limit.js
+++ b/backend/src/lib/rate-limit.js
@@ -19,6 +19,12 @@ export const SEP10_VERIFY_RATE_LIMIT_WINDOW_MS = Number(
 export const SEP10_VERIFY_RATE_LIMIT_MAX = Number(
   process.env.SEP10_VERIFY_RATE_LIMIT_MAX || 10,
 );
+export const DASHBOARD_METRICS_RATE_LIMIT_WINDOW_MS = Number(
+  process.env.DASHBOARD_METRICS_RATE_LIMIT_WINDOW_MS || 60 * 1000,
+);
+export const DASHBOARD_METRICS_RATE_LIMIT_MAX = Number(
+  process.env.DASHBOARD_METRICS_RATE_LIMIT_MAX || 30,
+);
 
 function setStandardRateLimitHeaders(res, rateLimitState) {
   if (!res || !rateLimitState) {
@@ -189,6 +195,52 @@ export function createSep10VerifyRateLimit({
     legacyHeaders: false,
     validate: { ip: false },
     keyGenerator: getSep10VerifyRateLimitKey,
+    handler: (req, res, _next, options) => {
+      setStandardRateLimitHeaders(res, req.rateLimit);
+      res.status(options.statusCode).json(options.message);
+    },
+    store,
+    passOnStoreError: true,
+  });
+}
+
+export function getDashboardMetricsRateLimitKey(req) {
+  const merchantId =
+    typeof req?.merchant?.id === "string" && req.merchant.id.length > 0
+      ? `merchant:${req.merchant.id}`
+      : null;
+  const apiKey =
+    typeof req?.headers?.["x-api-key"] === "string" &&
+    req.headers["x-api-key"].length > 0
+      ? `api:${createHash("sha256").update(req.headers["x-api-key"]).digest("hex")}`
+      : null;
+  const ipKey = ipKeyGenerator(req?.ip ?? req?.socket?.remoteAddress ?? "unknown-ip");
+
+  return merchantId ?? apiKey ?? `ip:${ipKey}`;
+}
+
+/**
+ * Per-merchant rate limit for the admin dashboard metrics endpoints
+ * (summary/revenue/volume). These queries aggregate over the full payments
+ * table, so unrestricted polling can add significant load (issue #927).
+ */
+export function createDashboardMetricsRateLimit({
+  store,
+  rateLimitFactory = rateLimit,
+  max = DASHBOARD_METRICS_RATE_LIMIT_MAX,
+  windowMs = DASHBOARD_METRICS_RATE_LIMIT_WINDOW_MS,
+} = {}) {
+  return rateLimitFactory({
+    windowMs,
+    max,
+    message: {
+      error: "Too many dashboard requests, please try again later.",
+      code: "DASHBOARD_METRICS_RATE_LIMITED",
+    },
+    standardHeaders: true,
+    legacyHeaders: false,
+    validate: { ip: false },
+    keyGenerator: getDashboardMetricsRateLimitKey,
     handler: (req, res, _next, options) => {
       setStandardRateLimitHeaders(res, req.rateLimit);
       res.status(options.statusCode).json(options.message);

--- a/backend/src/lib/rate-limit.test.js
+++ b/backend/src/lib/rate-limit.test.js
@@ -9,11 +9,15 @@ vi.mock("redis", () => ({
 }));
 
 import {
+  createDashboardMetricsRateLimit,
   createMerchantSecurityActionRateLimit,
   createRedisRateLimitStore,
   createSep10ChallengeRateLimit,
   createSep10VerifyRateLimit,
   createVerifyPaymentRateLimit,
+  DASHBOARD_METRICS_RATE_LIMIT_MAX,
+  DASHBOARD_METRICS_RATE_LIMIT_WINDOW_MS,
+  getDashboardMetricsRateLimitKey,
   getMerchantSecurityActionRateLimitKey,
   getSep10ChallengeRateLimitKey,
   getSep10VerifyRateLimitKey,
@@ -153,6 +157,63 @@ describe("getMerchantSecurityActionRateLimitKey", () => {
         ip: "203.0.113.10",
       }),
     ).toMatch(/^api:[a-f0-9]{64}$/);
+  });
+});
+
+describe("createDashboardMetricsRateLimit", () => {
+  it("passes the dashboard metrics config into express-rate-limit", () => {
+    const store = { kind: "redis-store" };
+    const middleware = vi.fn();
+    const rateLimitFactory = vi.fn(() => middleware);
+
+    const result = createDashboardMetricsRateLimit({ store, rateLimitFactory });
+
+    expect(result).toBe(middleware);
+    expect(rateLimitFactory).toHaveBeenCalledWith({
+      windowMs: DASHBOARD_METRICS_RATE_LIMIT_WINDOW_MS,
+      max: DASHBOARD_METRICS_RATE_LIMIT_MAX,
+      message: {
+        error: "Too many dashboard requests, please try again later.",
+        code: "DASHBOARD_METRICS_RATE_LIMITED",
+      },
+      standardHeaders: true,
+      legacyHeaders: false,
+      validate: { ip: false },
+      keyGenerator: expect.any(Function),
+      handler: expect.any(Function),
+      store,
+      passOnStoreError: true,
+    });
+  });
+});
+
+describe("getDashboardMetricsRateLimitKey", () => {
+  it("uses merchant ids when available", () => {
+    expect(
+      getDashboardMetricsRateLimitKey({
+        merchant: { id: "merchant-789" },
+        headers: {},
+        ip: "203.0.113.10",
+      }),
+    ).toBe("merchant:merchant-789");
+  });
+
+  it("hashes api keys when merchant context is unavailable", () => {
+    expect(
+      getDashboardMetricsRateLimitKey({
+        headers: { "x-api-key": "dashboard-secret-key" },
+        ip: "203.0.113.10",
+      }),
+    ).toMatch(/^api:[a-f0-9]{64}$/);
+  });
+
+  it("falls back to ip-based keys when no merchant or api key is available", () => {
+    expect(
+      getDashboardMetricsRateLimitKey({
+        headers: {},
+        ip: "203.0.113.10",
+      }),
+    ).toBe("ip:203.0.113.10");
   });
 });
 

--- a/backend/src/routes/metrics.js
+++ b/backend/src/routes/metrics.js
@@ -1,117 +1,116 @@
 import express from "express";
 import { requireApiKeyAuth } from "../lib/auth.js";
-import { withMerchantContext } from "../lib/db-rls.js";
 import { validateRequest } from "../lib/validation.js";
 import { metricsVolumeQuerySchema } from "../lib/request-schemas.js";
+import { metricService } from "../services/metricService.js";
+import { createDashboardMetricsRateLimit } from "../lib/rate-limit.js";
 
-const router = express.Router();
-
-/**
- * @swagger
- * /api/metrics/summary:
- *   get:
- *     summary: Get monthly revenue summary grouped by asset
- *     tags: [Metrics]
- *     security:
- *       - ApiKeyAuth: []
- */
-router.get("/metrics/summary", requireApiKeyAuth(), async (req, res, next) => {
-  try {
-    const pool = req.app.locals.pool;
-    const result = await metricService.getMonthlySummary(pool, req.merchant.id);
-    res.json(result);
-  } catch (err) {
-    next(err);
-  }
-});
+const defaultDashboardMetricsRateLimit = createDashboardMetricsRateLimit();
 
 /**
- * @swagger
- * /api/metrics/revenue:
- *   get:
- *     summary: Get aggregate revenue by asset
- *     tags: [Metrics]
- *     security:
- *       - ApiKeyAuth: []
+ * Admin Dashboard Service routes (revenue summary, revenue by asset, volume
+ * over time). All routes require a signed, rate-limited API key request:
+ *  - requireApiKeyAuth({ requireSignature: true }) enforces HMAC request
+ *    signing via the existing x-api-signature/x-api-timestamp headers
+ *    (issue #928).
+ *  - dashboardMetricsRateLimit caps how often a merchant can poll these
+ *    aggregate queries (issue #927).
  */
-router.get("/metrics/revenue", requireApiKeyAuth(), async (req, res, next) => {
-  try {
-    const pool = req.app.locals.pool;
-    const result = await metricService.getRevenueByAsset(pool, req.merchant.id);
-    res.json(result);
-  } catch (err) {
-    next(err);
-  }
-});
+function createMetricsRouter({
+  dashboardMetricsRateLimit = defaultDashboardMetricsRateLimit,
+} = {}) {
+  const router = express.Router();
 
-/**
- * @swagger
- * /api/metrics/volume:
- *   get:
- *     summary: Get per-asset daily volume for a time range
- *     tags: [Metrics]
- *     security:
- *       - ApiKeyAuth: []
- */
-router.get("/metrics/volume", requireApiKeyAuth(), validateRequest({ query: metricsVolumeQuerySchema }), async (req, res, next) => {
-  try {
-    const pool = req.app.locals.pool;
-    const merchantId = req.merchant.id;
-    const VALID_RANGES = { "7D": 7, "30D": 30, "1Y": 365 };
-    const range = req.query.range;
-    const days = VALID_RANGES[range];
-
-    const query = `
-      SELECT
-        date_trunc('day', created_at) AS date,
-        asset,
-        SUM(amount) AS volume,
-        COUNT(*) AS count
-      FROM payments
-      WHERE merchant_id = $1
-        AND status = 'completed'
-        AND created_at >= NOW() - INTERVAL '${days} days'
-      GROUP BY 1, 2
-      ORDER BY 1 ASC, 2 ASC
-    `;
-
-    const { rows } = await pool.query(query, [merchantId]);
-    const assetSet = new Set(rows.map((row) => row.asset));
-    const assets = Array.from(assetSet);
-
-    const byDate = {};
-    for (const row of rows) {
-      const dateStr = row.date.toISOString().split("T")[0];
-      if (!byDate[dateStr]) {
-        byDate[dateStr] = { date: dateStr, count: 0 };
+  /**
+   * @swagger
+   * /api/metrics/summary:
+   *   get:
+   *     summary: Get monthly revenue summary grouped by asset
+   *     tags: [Metrics]
+   *     security:
+   *       - ApiKeyAuth: []
+   *     responses:
+   *       429:
+   *         description: Rate limit exceeded
+   */
+  router.get(
+    "/metrics/summary",
+    requireApiKeyAuth({ requireSignature: true }),
+    dashboardMetricsRateLimit,
+    async (req, res, next) => {
+      try {
+        const pool = req.app.locals.pool;
+        const result = await metricService.getMonthlySummary(pool, req.merchant.id);
+        res.json(result);
+      } catch (err) {
+        next(err);
       }
+    },
+  );
 
-      byDate[dateStr][row.asset] = parseFloat(row.volume) || 0;
-      byDate[dateStr].count += parseInt(row.count, 10) || 0;
-    }
-
-    const now = new Date();
-    const result = [];
-    for (let i = days - 1; i >= 0; i -= 1) {
-      const day = new Date(now);
-      day.setDate(day.getDate() - i);
-      const dateStr = day.toISOString().split("T")[0];
-      const entry = byDate[dateStr] || { date: dateStr, count: 0 };
-
-      for (const asset of assets) {
-        if (entry[asset] === undefined) entry[asset] = 0;
+  /**
+   * @swagger
+   * /api/metrics/revenue:
+   *   get:
+   *     summary: Get aggregate revenue by asset
+   *     tags: [Metrics]
+   *     security:
+   *       - ApiKeyAuth: []
+   *     responses:
+   *       429:
+   *         description: Rate limit exceeded
+   */
+  router.get(
+    "/metrics/revenue",
+    requireApiKeyAuth({ requireSignature: true }),
+    dashboardMetricsRateLimit,
+    async (req, res, next) => {
+      try {
+        const pool = req.app.locals.pool;
+        const result = await metricService.getRevenueByAsset(pool, req.merchant.id);
+        res.json(result);
+      } catch (err) {
+        next(err);
       }
+    },
+  );
 
-      result.push(entry);
-    }
+  /**
+   * @swagger
+   * /api/metrics/volume:
+   *   get:
+   *     summary: Get per-asset daily volume for a time range
+   *     tags: [Metrics]
+   *     security:
+   *       - ApiKeyAuth: []
+   *     responses:
+   *       429:
+   *         description: Rate limit exceeded
+   */
+  router.get(
+    "/metrics/volume",
+    requireApiKeyAuth({ requireSignature: true }),
+    dashboardMetricsRateLimit,
+    validateRequest({ query: metricsVolumeQuerySchema }),
+    async (req, res, next) => {
+      try {
+        const pool = req.app.locals.pool;
+        const result = await metricService.getVolumeOverTime(
+          pool,
+          req.merchant.id,
+          req.query.range,
+        );
+        res.json(result);
+      } catch (err) {
+        if (err.message.includes("Invalid range")) {
+          return res.status(400).json({ error: err.message });
+        }
+        next(err);
+      }
+    },
+  );
 
-    res.json({ range, assets, data: result });
-  } catch (err) {
-    if (err.message.includes("Invalid range")) {
-      return res.status(400).json({ error: err.message });
-    }
-    next(err);
-  }
-});
+  return router;
+}
 
-export default router;
+export default createMetricsRouter;

--- a/backend/src/routes/metrics.test.js
+++ b/backend/src/routes/metrics.test.js
@@ -1,0 +1,100 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockRequireApiKeyAuth,
+  mockAuthMiddleware,
+  mockGetMonthlySummary,
+  mockGetRevenueByAsset,
+  mockGetVolumeOverTime,
+} = vi.hoisted(() => ({
+  mockAuthMiddleware: (req, _res, next) => {
+    req.merchant = { id: "merchant_123" };
+    next();
+  },
+  mockRequireApiKeyAuth: vi.fn(),
+  mockGetMonthlySummary: vi.fn(),
+  mockGetRevenueByAsset: vi.fn(),
+  mockGetVolumeOverTime: vi.fn(),
+}));
+
+vi.mock("../lib/auth.js", () => ({
+  requireApiKeyAuth: mockRequireApiKeyAuth,
+}));
+
+vi.mock("../services/metricService.js", () => ({
+  metricService: {
+    getMonthlySummary: mockGetMonthlySummary,
+    getRevenueByAsset: mockGetRevenueByAsset,
+    getVolumeOverTime: mockGetVolumeOverTime,
+  },
+}));
+
+import createMetricsRouter from "./metrics.js";
+
+function createApp({ dashboardMetricsRateLimit } = {}) {
+  const app = express();
+  app.use(express.json());
+  app.locals.pool = {};
+  app.use("/api", createMetricsRouter({ dashboardMetricsRateLimit }));
+  return app;
+}
+
+describe("Metrics (Admin Dashboard) routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireApiKeyAuth.mockReturnValue(mockAuthMiddleware);
+  });
+
+  it("requires a signed API key request (requireApiKeyAuth invoked with requireSignature: true)", async () => {
+    mockGetMonthlySummary.mockResolvedValue({ last_month: {}, current_month: {} });
+
+    const app = createApp({ dashboardMetricsRateLimit: (_req, _res, next) => next() });
+    await request(app).get("/api/metrics/summary");
+
+    expect(mockRequireApiKeyAuth).toHaveBeenCalledWith({ requireSignature: true });
+  });
+
+  it("returns 429 when the dashboard rate limit rejects the request", async () => {
+    const rateLimited = (_req, res) =>
+      res.status(429).json({ error: "Too many dashboard requests, please try again later." });
+
+    const app = createApp({ dashboardMetricsRateLimit: rateLimited });
+    const response = await request(app).get("/api/metrics/revenue");
+
+    expect(response.status).toBe(429);
+    expect(mockGetRevenueByAsset).not.toHaveBeenCalled();
+  });
+
+  it("GET /api/metrics/summary returns the monthly summary for the authenticated merchant", async () => {
+    mockGetMonthlySummary.mockResolvedValue({
+      last_month: { by_asset: [], total: 0 },
+      current_month: { by_asset: [], total: 0 },
+    });
+
+    const app = createApp({ dashboardMetricsRateLimit: (_req, _res, next) => next() });
+    const response = await request(app).get("/api/metrics/summary");
+
+    expect(response.status).toBe(200);
+    expect(mockGetMonthlySummary).toHaveBeenCalledWith(expect.anything(), "merchant_123");
+  });
+
+  it("GET /api/metrics/volume validates the range query param", async () => {
+    const app = createApp({ dashboardMetricsRateLimit: (_req, _res, next) => next() });
+    const response = await request(app).get("/api/metrics/volume?range=BOGUS");
+
+    expect(response.status).toBe(400);
+    expect(mockGetVolumeOverTime).not.toHaveBeenCalled();
+  });
+
+  it("GET /api/metrics/volume delegates to metricService for a valid range", async () => {
+    mockGetVolumeOverTime.mockResolvedValue({ range: "7D", assets: [], data: [] });
+
+    const app = createApp({ dashboardMetricsRateLimit: (_req, _res, next) => next() });
+    const response = await request(app).get("/api/metrics/volume?range=7D");
+
+    expect(response.status).toBe(200);
+    expect(mockGetVolumeOverTime).toHaveBeenCalledWith(expect.anything(), "merchant_123", "7D");
+  });
+});

--- a/backend/src/services/metricService.js
+++ b/backend/src/services/metricService.js
@@ -1,99 +1,127 @@
 import { withMerchantContext } from "../lib/db-rls.js";
+import { queryWithRetry, circuitBreaker, isRetryablePoolError } from "../lib/db.js";
+
+const VALID_VOLUME_RANGES = { "7D": 7, "30D": 30, "1Y": 365 };
+const RLS_QUERY_RETRY_ATTEMPTS = Number.parseInt(
+  process.env.DB_POOL_RETRY_ATTEMPTS || "2",
+  10,
+);
+const RLS_QUERY_RETRY_DELAY_MS = Number.parseInt(
+  process.env.DB_POOL_RETRY_DELAY_MS || "150",
+  10,
+);
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Run an RLS-scoped query (via withMerchantContext) with retry + the shared
+ * circuit breaker. A statement can't be retried mid-transaction once the
+ * connection drops, so each attempt opens a brand-new transaction on a fresh
+ * client instead of retrying within one (issue #930).
+ */
+async function withMerchantContextRetry(merchantId, callback, { label = "rls-query" } = {}) {
+  return circuitBreaker.execute(async () => {
+    let lastError;
+
+    for (let attempt = 0; attempt <= RLS_QUERY_RETRY_ATTEMPTS; attempt += 1) {
+      try {
+        return await withMerchantContext(merchantId, callback);
+      } catch (err) {
+        lastError = err;
+        const shouldRetry = attempt < RLS_QUERY_RETRY_ATTEMPTS && isRetryablePoolError(err);
+        if (!shouldRetry) {
+          throw err;
+        }
+        const delayMs = RLS_QUERY_RETRY_DELAY_MS * (attempt + 1);
+        console.warn(
+          `[metricService] ${label} failed (attempt ${attempt + 1}/${RLS_QUERY_RETRY_ATTEMPTS + 1}): ${err.message}. Retrying in ${delayMs}ms.`,
+        );
+        await sleep(delayMs);
+      }
+    }
+
+    throw lastError;
+  });
+}
 
 export const metricService = {
+  /**
+   * Retrieve last-month and current-month revenue in a single round trip.
+   *
+   * Previously this issued two separate sequential queries on the same RLS
+   * client. Both share the same WHERE shape (merchant_id, status, GROUP BY
+   * asset/asset_issuer) and the same (merchant_id, status, created_at) index,
+   * so they are merged into one query using conditional aggregation —
+   * halving DB round trips for this endpoint (issue #929).
+   */
   async getMonthlySummary(pool, merchantId) {
-    // Calculate date ranges for last month and current month
     const now = new Date();
     const currentYear = now.getFullYear();
     const currentMonth = now.getMonth(); // 0-indexed (0 = January)
 
-    // Last month
     const lastMonth = currentMonth === 0 ? 11 : currentMonth - 1;
     const lastMonthYear = currentMonth === 0 ? currentYear - 1 : currentYear;
 
-    // First day of current month
     const currentMonthStart = new Date(currentYear, currentMonth, 1);
-    // First day of last month
     const lastMonthStart = new Date(lastMonthYear, lastMonth, 1);
-    // Last day of last month (day before first day of current month)
-    const lastMonthEnd = new Date(
-      currentYear,
-      currentMonth,
-      0,
-      23,
-      59,
-      59,
-      999
-    );
+    const lastMonthEnd = new Date(currentYear, currentMonth, 0, 23, 59, 59, 999);
 
-    // Query for last month's revenue
-    const lastMonthQuery = `
+    const combinedQuery = `
       SELECT
         asset,
         asset_issuer,
-        SUM(amount) as total,
-        COUNT(*) as count
+        SUM(amount) FILTER (WHERE created_at >= $2 AND created_at <= $3) AS last_month_total,
+        COUNT(*) FILTER (WHERE created_at >= $2 AND created_at <= $3) AS last_month_count,
+        SUM(amount) FILTER (WHERE created_at >= $4) AS current_month_total,
+        COUNT(*) FILTER (WHERE created_at >= $4) AS current_month_count
       FROM payments
-      WHERE merchant_id = $1 
-        AND status = 'completed'
-        AND created_at >= $2 
-        AND created_at <= $3
-      GROUP BY asset, asset_issuer
-      ORDER BY asset, asset_issuer
-    `;
-
-    // Query for current month's revenue
-    const currentMonthQuery = `
-      SELECT
-        asset,
-        asset_issuer,
-        SUM(amount) as total,
-        COUNT(*) as count
-      FROM payments
-      WHERE merchant_id = $1 
+      WHERE merchant_id = $1
         AND status = 'completed'
         AND created_at >= $2
       GROUP BY asset, asset_issuer
       ORDER BY asset, asset_issuer
     `;
 
-    const { lastMonthResult, currentMonthResult } = await withMerchantContext(
+    const { rows } = await withMerchantContextRetry(
       merchantId,
-      async (client) => {
-        const last = await client.query(lastMonthQuery, [
+      (client) =>
+        client.query(combinedQuery, [
           merchantId,
           lastMonthStart,
           lastMonthEnd,
-        ]);
-        const current = await client.query(currentMonthQuery, [
-          merchantId,
           currentMonthStart,
-        ]);
-        return { lastMonthResult: last, currentMonthResult: current };
-      }
+        ]),
+      { label: "metrics-monthly-summary" },
     );
 
-    // Format last month data
-    const lastMonthByAsset = lastMonthResult.rows.map((row) => ({
-      asset: row.asset,
-      asset_issuer: row.asset_issuer,
-      total: row.total || "0",
-      count: parseInt(row.count, 10),
-    }));
+    const lastMonthByAsset = [];
+    const currentMonthByAsset = [];
+
+    for (const row of rows) {
+      if (row.last_month_count > 0) {
+        lastMonthByAsset.push({
+          asset: row.asset,
+          asset_issuer: row.asset_issuer,
+          total: row.last_month_total || "0",
+          count: parseInt(row.last_month_count, 10),
+        });
+      }
+      if (row.current_month_count > 0) {
+        currentMonthByAsset.push({
+          asset: row.asset,
+          asset_issuer: row.asset_issuer,
+          total: row.current_month_total || "0",
+          count: parseInt(row.current_month_count, 10),
+        });
+      }
+    }
 
     const lastMonthTotal = lastMonthByAsset.reduce(
       (sum, item) => sum + parseFloat(item.total),
       0
     );
-
-    // Format current month data
-    const currentMonthByAsset = currentMonthResult.rows.map((row) => ({
-      asset: row.asset,
-      asset_issuer: row.asset_issuer,
-      total: row.total || "0",
-      count: parseInt(row.count, 10),
-    }));
-
     const currentMonthTotal = currentMonthByAsset.reduce(
       (sum, item) => sum + parseFloat(item.total),
       0
@@ -129,7 +157,9 @@ export const metricService = {
       ORDER BY asset, asset_issuer
     `;
 
-    const { rows } = await pool.query(query, [merchantId]);
+    const { rows } = await queryWithRetry(query, [merchantId], {
+      label: "metrics-revenue-by-asset",
+    });
 
     return {
       revenue: rows.map((row) => ({
@@ -142,8 +172,7 @@ export const metricService = {
   },
 
   async getVolumeOverTime(pool, merchantId, range) {
-    const VALID_RANGES = { "7D": 7, "30D": 30, "1Y": 365 };
-    const days = VALID_RANGES[range];
+    const days = VALID_VOLUME_RANGES[range];
 
     if (!days) {
       throw new Error("Invalid range. Use 7D, 30D, or 1Y.");
@@ -153,7 +182,8 @@ export const metricService = {
       SELECT
         date_trunc('day', created_at) AS date,
         asset,
-        SUM(amount) AS volume
+        SUM(amount) AS volume,
+        COUNT(*) AS count
       FROM payments
       WHERE merchant_id = $1
         AND status = 'completed'
@@ -162,7 +192,9 @@ export const metricService = {
       ORDER BY 1 ASC, 2 ASC
     `;
 
-    const { rows } = await pool.query(query, [merchantId, days]);
+    const { rows } = await queryWithRetry(query, [merchantId, days], {
+      label: "metrics-volume-over-time",
+    });
 
     // Collect all distinct assets across the result set
     const assetSet = new Set(rows.map((r) => r.asset));
@@ -172,8 +204,11 @@ export const metricService = {
     const byDate = {};
     for (const row of rows) {
       const dateStr = row.date.toISOString().split("T")[0];
-      if (!byDate[dateStr]) byDate[dateStr] = { date: dateStr };
+      if (!byDate[dateStr]) {
+        byDate[dateStr] = { date: dateStr, count: 0 };
+      }
       byDate[dateStr][row.asset] = parseFloat(row.volume) || 0;
+      byDate[dateStr].count += parseInt(row.count, 10) || 0;
     }
 
     // Fill gaps
@@ -183,7 +218,7 @@ export const metricService = {
       const d = new Date(now);
       d.setDate(d.getDate() - i);
       const dateStr = d.toISOString().split("T")[0];
-      const entry = byDate[dateStr] || { date: dateStr };
+      const entry = byDate[dateStr] || { date: dateStr, count: 0 };
       for (const asset of assets) {
         if (entry[asset] === undefined) entry[asset] = 0;
       }

--- a/backend/src/services/metricService.test.js
+++ b/backend/src/services/metricService.test.js
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPoolQuery, mockClientQuery, mockIsRetryablePoolError, mockCircuitExecute } = vi.hoisted(() => ({
+  mockPoolQuery: vi.fn(),
+  mockClientQuery: vi.fn(),
+  mockIsRetryablePoolError: vi.fn(() => false),
+  mockCircuitExecute: vi.fn((fn) => fn()),
+}));
+
+vi.mock("../lib/db.js", () => ({
+  pool: { query: mockPoolQuery },
+  isRetryablePoolError: mockIsRetryablePoolError,
+  circuitBreaker: { execute: mockCircuitExecute },
+  queryWithRetry: async (text, values) => {
+    return mockPoolQuery(text, values);
+  },
+}));
+
+vi.mock("../lib/db-rls.js", () => ({
+  withMerchantContext: async (_merchantId, callback) => {
+    return callback({ query: mockClientQuery });
+  },
+}));
+
+import { metricService } from "./metricService.js";
+
+describe("metricService.getMonthlySummary", () => {
+  beforeEach(() => {
+    mockClientQuery.mockReset();
+    mockCircuitExecute.mockReset();
+    mockCircuitExecute.mockImplementation((fn) => fn());
+  });
+
+  it("issues a single combined query instead of two sequential queries", async () => {
+    mockClientQuery.mockResolvedValue({
+      rows: [
+        {
+          asset: "USDC",
+          asset_issuer: "GISSUER",
+          last_month_total: "100.0000000",
+          last_month_count: 2,
+          current_month_total: "50.0000000",
+          current_month_count: 1,
+        },
+      ],
+    });
+
+    const result = await metricService.getMonthlySummary(null, "merchant-1");
+
+    expect(mockClientQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockClientQuery.mock.calls[0];
+    expect(sql).toMatch(/FILTER \(WHERE/);
+    expect(params[0]).toBe("merchant-1");
+
+    expect(result.last_month.by_asset).toEqual([
+      { asset: "USDC", asset_issuer: "GISSUER", total: "100.0000000", count: 2 },
+    ]);
+    expect(result.current_month.by_asset).toEqual([
+      { asset: "USDC", asset_issuer: "GISSUER", total: "50.0000000", count: 1 },
+    ]);
+    expect(result.last_month.total).toBe(100);
+    expect(result.current_month.total).toBe(50);
+  });
+
+  it("omits assets with zero activity in a given period", async () => {
+    mockClientQuery.mockResolvedValue({
+      rows: [
+        {
+          asset: "XLM",
+          asset_issuer: null,
+          last_month_total: null,
+          last_month_count: 0,
+          current_month_total: "10.0000000",
+          current_month_count: 1,
+        },
+      ],
+    });
+
+    const result = await metricService.getMonthlySummary(null, "merchant-1");
+
+    expect(result.last_month.by_asset).toEqual([]);
+    expect(result.current_month.by_asset).toEqual([
+      { asset: "XLM", asset_issuer: null, total: "10.0000000", count: 1 },
+    ]);
+  });
+
+  it("retries on a retryable connection error and succeeds on the next attempt", async () => {
+    mockIsRetryablePoolError.mockReturnValueOnce(true);
+    mockClientQuery
+      .mockRejectedValueOnce(Object.assign(new Error("connection terminated"), { code: "08006" }))
+      .mockResolvedValueOnce({ rows: [] });
+
+    const result = await metricService.getMonthlySummary(null, "merchant-1");
+
+    expect(mockClientQuery).toHaveBeenCalledTimes(2);
+    expect(mockCircuitExecute).toHaveBeenCalledTimes(1);
+    expect(result.last_month.by_asset).toEqual([]);
+  });
+
+  it("does not retry non-retryable errors", async () => {
+    mockIsRetryablePoolError.mockReturnValueOnce(false);
+    mockClientQuery.mockRejectedValueOnce(new Error("syntax error"));
+
+    await expect(metricService.getMonthlySummary(null, "merchant-1")).rejects.toThrow(
+      "syntax error",
+    );
+    expect(mockClientQuery).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("metricService.getRevenueByAsset", () => {
+  beforeEach(() => {
+    mockPoolQuery.mockReset();
+  });
+
+  it("returns revenue grouped by asset", async () => {
+    mockPoolQuery.mockResolvedValue({
+      rows: [{ asset: "USDC", asset_issuer: "GISSUER", total: "10", count: "3" }],
+    });
+
+    const result = await metricService.getRevenueByAsset(null, "merchant-1");
+
+    expect(result.revenue).toEqual([
+      { asset: "USDC", asset_issuer: "GISSUER", total: "10", count: 3 },
+    ]);
+  });
+});
+
+describe("metricService.getVolumeOverTime", () => {
+  beforeEach(() => {
+    mockPoolQuery.mockReset();
+  });
+
+  it("rejects an invalid range before querying", async () => {
+    await expect(
+      metricService.getVolumeOverTime(null, "merchant-1", "BOGUS"),
+    ).rejects.toThrow("Invalid range");
+    expect(mockPoolQuery).not.toHaveBeenCalled();
+  });
+
+  it("fills date gaps for every asset across the requested range", async () => {
+    mockPoolQuery.mockResolvedValue({
+      rows: [
+        { date: new Date(), asset: "USDC", volume: "5", count: "1" },
+      ],
+    });
+
+    const result = await metricService.getVolumeOverTime(null, "merchant-1", "7D");
+
+    expect(result.range).toBe("7D");
+    expect(result.assets).toEqual(["USDC"]);
+    expect(result.data).toHaveLength(7);
+    expect(result.data.every((entry) => "USDC" in entry)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

This PR hardens the Admin Dashboard Service (the `/api/metrics/*` revenue/volume reporting endpoints and their backing `metricService`) across four areas: rate limiting, request signature verification, SQL query efficiency, and DB error recovery.

- **Rate limiting (#927):** Added `createDashboardMetricsRateLimit` / `getDashboardMetricsRateLimitKey` in `lib/rate-limit.js`, following the same per-merchant (falling back to hashed API key, then IP) keying pattern already used for merchant security actions and SEP-10 endpoints. Wired into `/api/metrics/summary`, `/api/metrics/revenue`, and `/api/metrics/volume` via a Redis-backed store when Redis is available, matching the existing wiring in `app.js`.
- **Signature verification (#928):** All three dashboard routes now require `requireApiKeyAuth({ requireSignature: true })`, enforcing the existing HMAC `x-api-signature` / `x-api-timestamp` request-signing scheme (already used by sensitive merchant routes) instead of relying on the API key alone.
- **SQL optimization (#929):**
  - Fixed a missing `metricService` import in `routes/metrics.js` — the route referenced `metricService` without importing it, which meant `/api/metrics/summary` and `/api/metrics/revenue` would throw a `ReferenceError` on every request.
  - Removed a duplicated inline SQL query in the `/api/metrics/volume` handler that re-implemented `metricService.getVolumeOverTime` instead of calling it.
  - Merged the two sequential last-month/current-month queries in `metricService.getMonthlySummary` into a single query using conditional aggregation (`FILTER (WHERE ...)`), halving the DB round trips for that endpoint while still using the existing `(merchant_id, status, created_at)` index.
- **Error recovery (#930):** All `metricService` DB calls now go through retry-with-backoff and the shared circuit breaker from `lib/db.js` (the same circuit breaker already protecting auth and audit-log writes), so transient connection errors are retried instead of surfacing as hard failures to the dashboard.

Also converted `routes/metrics.js` from a static router export to a `createMetricsRouter` factory so the rate limiter can be injected, matching the existing factory pattern used by `routes/payments.js` and `routes/merchants.js`.

## Test plan
- [x] Added `lib/rate-limit.test.js` coverage for `createDashboardMetricsRateLimit` / `getDashboardMetricsRateLimitKey`
- [x] Added `services/metricService.test.js` covering the combined summary query, zero-activity asset filtering, retry-then-succeed, and non-retryable failure paths
- [x] Added `routes/metrics.test.js` covering signature enforcement, rate-limit rejection (429), and successful delegation to `metricService` for all three routes
- [ ] Maintainer to run full CI (`npm test` in `backend/`) to confirm no regressions

Closes #927
Closes #928
Closes #929
Closes #930