### PR TITLE
implemented

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1,4 +1,29 @@
 {
+  "twoFactorAuth": {
+    "ariaLabel": "Two-factor authentication setup",
+    "stepsLabel": "Setup steps",
+    "title": "Enable Two-Factor Authentication",
+    "description": "Protect your account with an authenticator app. You will need to scan a QR code to get started.",
+    "enableButton": "Enable 2FA",
+    "settingUp": "Setting up…",
+    "scanTitle": "Scan with your authenticator app",
+    "scanDescription": "Use Google Authenticator, Authy, or any TOTP-compatible app to scan the code below.",
+    "qrCodeAlt": "TOTP QR code — scan with your authenticator app",
+    "qrCodeSkeletonLabel": "Generating QR code…",
+    "manualKeyLabel": "Or enter key manually",
+    "manualKeyAria": "Manual setup key: {key}",
+    "codeInputLabel": "Enter 6-digit code",
+    "codeInputPlaceholder": "000000",
+    "verifyButton": "Verify & Enable",
+    "verifying": "Verifying…",
+    "successTitle": "Two-Factor Authentication Enabled",
+    "successDescription": "Your account is now protected. You will be prompted for a code on each login.",
+    "error": {
+      "setupFailed": "Failed to start 2FA setup. Please try again.",
+      "invalidCode": "Invalid code. Please try again.",
+      "codeLength": "Please enter the 6-digit code from your authenticator app."
+    }
+  },
   "localeSwitcher": {
     "label": "Lang",
     "ariaLabel": "Select language",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -1,4 +1,29 @@
 {
+  "twoFactorAuth": {
+    "ariaLabel": "Configuracion de autenticacion en dos pasos",
+    "stepsLabel": "Pasos de configuracion",
+    "title": "Activar autenticacion en dos pasos",
+    "description": "Protege tu cuenta con una aplicacion de autenticacion. Necesitaras escanear un codigo QR para comenzar.",
+    "enableButton": "Activar 2FA",
+    "settingUp": "Configurando…",
+    "scanTitle": "Escanea con tu aplicacion de autenticacion",
+    "scanDescription": "Usa Google Authenticator, Authy o cualquier aplicacion compatible con TOTP para escanear el codigo.",
+    "qrCodeAlt": "Codigo QR TOTP — escanea con tu aplicacion de autenticacion",
+    "qrCodeSkeletonLabel": "Generando codigo QR…",
+    "manualKeyLabel": "O ingresa la clave manualmente",
+    "manualKeyAria": "Clave de configuracion manual: {key}",
+    "codeInputLabel": "Ingresa el codigo de 6 digitos",
+    "codeInputPlaceholder": "000000",
+    "verifyButton": "Verificar y activar",
+    "verifying": "Verificando…",
+    "successTitle": "Autenticacion en dos pasos activada",
+    "successDescription": "Tu cuenta esta ahora protegida. Se te pedira un codigo en cada inicio de sesion.",
+    "error": {
+      "setupFailed": "No se pudo iniciar la configuracion de 2FA. Intentalo de nuevo.",
+      "invalidCode": "Codigo invalido. Intentalo de nuevo.",
+      "codeLength": "Ingresa el codigo de 6 digitos de tu aplicacion de autenticacion."
+    }
+  },
   "localeSwitcher": {
     "label": "Idioma",
     "ariaLabel": "Seleccionar idioma",

--- a/frontend/messages/pt.json
+++ b/frontend/messages/pt.json
@@ -1,4 +1,29 @@
 {
+  "twoFactorAuth": {
+    "ariaLabel": "Configuracao de autenticacao em duas etapas",
+    "stepsLabel": "Etapas de configuracao",
+    "title": "Ativar autenticacao em duas etapas",
+    "description": "Proteja sua conta com um aplicativo de autenticacao. Voce precisara escanear um codigo QR para comecar.",
+    "enableButton": "Ativar 2FA",
+    "settingUp": "Configurando…",
+    "scanTitle": "Escaneie com seu aplicativo de autenticacao",
+    "scanDescription": "Use Google Authenticator, Authy ou qualquer aplicativo compativel com TOTP para escanear o codigo.",
+    "qrCodeAlt": "Codigo QR TOTP — escaneie com seu aplicativo de autenticacao",
+    "qrCodeSkeletonLabel": "Gerando codigo QR…",
+    "manualKeyLabel": "Ou insira a chave manualmente",
+    "manualKeyAria": "Chave de configuracao manual: {key}",
+    "codeInputLabel": "Insira o codigo de 6 digitos",
+    "codeInputPlaceholder": "000000",
+    "verifyButton": "Verificar e ativar",
+    "verifying": "Verificando…",
+    "successTitle": "Autenticacao em duas etapas ativada",
+    "successDescription": "Sua conta esta agora protegida. Voce sera solicitado um codigo em cada login.",
+    "error": {
+      "setupFailed": "Falha ao iniciar a configuracao de 2FA. Tente novamente.",
+      "invalidCode": "Codigo invalido. Tente novamente.",
+      "codeLength": "Insira o codigo de 6 digitos do seu aplicativo de autenticacao."
+    }
+  },
   "localeSwitcher": {
     "label": "Idioma",
     "ariaLabel": "Selecionar idioma",

--- a/frontend/src/components/TwoFactorAuthSetup.test.tsx
+++ b/frontend/src/components/TwoFactorAuthSetup.test.tsx
@@ -12,6 +12,44 @@ vi.mock("./ui/Spinner", () => ({
   ),
 }));
 
+vi.mock("next-intl", () => ({
+  useTranslations: () => {
+    const translations: Record<string, string> = {
+      "ariaLabel": "Two-factor authentication setup",
+      "stepsLabel": "Setup steps",
+      "title": "Enable Two-Factor Authentication",
+      "description": "Protect your account with an authenticator app. You will need to scan a QR code to get started.",
+      "enableButton": "Enable 2FA",
+      "settingUp": "Setting up…",
+      "scanTitle": "Scan with your authenticator app",
+      "scanDescription": "Use Google Authenticator, Authy, or any TOTP-compatible app to scan the code below.",
+      "qrCodeAlt": "TOTP QR code — scan with your authenticator app",
+      "qrCodeSkeletonLabel": "Generating QR code…",
+      "manualKeyLabel": "Or enter key manually",
+      "codeInputLabel": "Enter 6-digit code",
+      "codeInputPlaceholder": "000000",
+      "verifyButton": "Verify & Enable",
+      "verifying": "Verifying…",
+      "successTitle": "Two-Factor Authentication Enabled",
+      "successDescription": "Your account is now protected. You will be prompted for a code on each login.",
+      "error.setupFailed": "Failed to start 2FA setup. Please try again.",
+      "error.invalidCode": "Invalid code. Please try again.",
+      "error.codeLength": "Please enter the 6-digit code from your authenticator app.",
+    };
+
+    return (key: string, params?: Record<string, string>) => {
+      const value = translations[key] || key;
+      if (params) {
+        return Object.entries(params).reduce(
+          (acc, [k, v]) => acc.replace(`{${k}}`, v),
+          value
+        );
+      }
+      return value;
+    };
+  },
+}));
+
 const SUCCESS_RESULT = {
   qrDataUrl: "data:image/png;base64,mock-qr",
   manualKey: "JBSWY3DPEHPK3PXP",

--- a/frontend/src/components/TwoFactorAuthSetup.tsx
+++ b/frontend/src/components/TwoFactorAuthSetup.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useId } from "react";
+import { useTranslations } from "next-intl";
 import { Spinner } from "./ui/Spinner";
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -18,12 +19,12 @@ interface TwoFactorAuthSetupProps {
 
 // ── Skeleton helpers ─────────────────────────────────────────────────────────
 
-function QrSkeleton() {
+function QrSkeleton({ t }: { t: ReturnType<typeof useTranslations> }) {
   return (
     <div
       className="mx-auto h-48 w-48 animate-pulse rounded-xl bg-white/10"
       aria-busy="true"
-      aria-label="Generating QR code…"
+      aria-label={t("qrCodeSkeletonLabel")}
       role="img"
     />
   );
@@ -70,6 +71,7 @@ export function TwoFactorAuthSetup({
   onVerifyCode,
 }: TwoFactorAuthSetupProps) {
   const codeInputId = useId();
+  const t = useTranslations("twoFactorAuth");
   const [step, setStep] = useState<SetupStep>("idle");
   const [code, setCode] = useState("");
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
@@ -92,7 +94,7 @@ export function TwoFactorAuthSetup({
       setManualKey(result.manualKey);
       setStep("scan");
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to start 2FA setup. Please try again.");
+      setError(err instanceof Error ? err.message : t("error.setupFailed"));
       setStep("idle");
     }
   };
@@ -101,7 +103,7 @@ export function TwoFactorAuthSetup({
 
   const handleVerify = async () => {
     if (code.trim().length !== 6) {
-      setError("Please enter the 6-digit code from your authenticator app.");
+      setError(t("error.codeLength"));
       return;
     }
     setStep("verifying");
@@ -112,7 +114,7 @@ export function TwoFactorAuthSetup({
       setStep("success");
       onComplete?.();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Invalid code. Please try again.");
+      setError(err instanceof Error ? err.message : t("error.invalidCode"));
       setStep("scan");
     }
   };
@@ -124,12 +126,12 @@ export function TwoFactorAuthSetup({
 
   return (
     <section
-      aria-label="Two-factor authentication setup"
+      aria-label={t("ariaLabel")}
       aria-busy={isBusy}
       className="flex flex-col gap-6"
     >
       {/* Progress indicator */}
-      <div className="flex items-center gap-0" role="list" aria-label="Setup steps">
+      <div className="flex items-center gap-0" role="list" aria-label={t("stepsLabel")}>
         <div role="listitem">
           <StepDot active={step === "idle" || step === "enabling"} done={scanVisible || isDone} label="1" />
         </div>
@@ -153,9 +155,9 @@ export function TwoFactorAuthSetup({
             </svg>
           </div>
           <div>
-            <h3 className="text-base font-semibold text-white">Enable Two-Factor Authentication</h3>
+            <h3 className="text-base font-semibold text-white">{t("title")}</h3>
             <p className="mt-1 text-sm text-slate-400">
-              Protect your account with an authenticator app. You will need to scan a QR code to get started.
+              {t("description")}
             </p>
           </div>
           <button
@@ -168,10 +170,10 @@ export function TwoFactorAuthSetup({
             {isEnabling ? (
               <>
                 <Spinner size="sm" aria-hidden="true" />
-                <span>Setting up…</span>
+                <span>{t("settingUp")}</span>
               </>
             ) : (
-              "Enable 2FA"
+              t("enableButton")
             )}
           </button>
         </div>
@@ -181,9 +183,9 @@ export function TwoFactorAuthSetup({
       {scanVisible && (
         <div className="flex flex-col gap-5">
           <div>
-            <h3 className="text-sm font-semibold text-white">Scan with your authenticator app</h3>
+            <h3 className="text-sm font-semibold text-white">{t("scanTitle")}</h3>
             <p className="mt-1 text-xs text-slate-400">
-              Use Google Authenticator, Authy, or any TOTP-compatible app to scan the code below.
+              {t("scanDescription")}
             </p>
           </div>
 
@@ -192,21 +194,21 @@ export function TwoFactorAuthSetup({
             {qrDataUrl ? (
               <img
                 src={qrDataUrl}
-                alt="TOTP QR code — scan with your authenticator app"
+                alt={t("qrCodeAlt")}
                 className="h-48 w-48 rounded-xl border border-white/10 bg-white p-2"
                 width={192}
                 height={192}
               />
             ) : (
-              <QrSkeleton />
+              <QrSkeleton t={t} />
             )}
           </div>
 
           {/* Manual key fallback */}
           {manualKey && (
             <div className="rounded-xl border border-white/10 bg-white/5 px-4 py-3">
-              <p className="text-[10px] uppercase tracking-widest text-slate-500">Or enter key manually</p>
-              <p className="mt-1 break-all font-mono text-xs text-mint" aria-label={`Manual setup key: ${manualKey}`}>
+              <p className="text-[10px] uppercase tracking-widest text-slate-500">{t("manualKeyLabel")}</p>
+              <p className="mt-1 break-all font-mono text-xs text-mint" aria-label={t("manualKeyAria", { key: manualKey })}>
                 {manualKey}
               </p>
             </div>
@@ -215,7 +217,7 @@ export function TwoFactorAuthSetup({
           {/* Code input */}
           <div className="flex flex-col gap-2">
             <label htmlFor={codeInputId} className="text-xs font-semibold text-white">
-              Enter 6-digit code
+              {t("codeInputLabel")}
             </label>
             <input
               id={codeInputId}
@@ -232,7 +234,7 @@ export function TwoFactorAuthSetup({
               aria-busy={isVerifying}
               aria-invalid={!!error && step === "scan"}
               aria-describedby={error ? "2fa-error" : undefined}
-              placeholder="000000"
+              placeholder={t("codeInputPlaceholder")}
               className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-center font-mono text-xl tracking-[0.4em] text-white placeholder:text-slate-600 focus:border-mint/50 focus:outline-none focus:ring-1 focus:ring-mint/50 disabled:opacity-50"
             />
             {error && (
@@ -252,10 +254,10 @@ export function TwoFactorAuthSetup({
             {isVerifying ? (
               <>
                 <Spinner size="sm" aria-hidden="true" />
-                <span>Verifying…</span>
+                <span>{t("verifying")}</span>
               </>
             ) : (
-              "Verify & Enable"
+              t("verifyButton")
             )}
           </button>
         </div>
@@ -270,9 +272,9 @@ export function TwoFactorAuthSetup({
             </svg>
           </div>
           <div>
-            <h3 className="text-base font-semibold text-white">Two-Factor Authentication Enabled</h3>
+            <h3 className="text-base font-semibold text-white">{t("successTitle")}</h3>
             <p className="mt-1 text-sm text-slate-400">
-              Your account is now protected. You will be prompted for a code on each login.
+              {t("successDescription")}
             </p>
           </div>
         </div>


### PR DESCRIPTION

---

## PR: feat(frontend): implement internationalization (i18n) support for Two-Factor Authentication Setup Flow

Closes #1207
Closes #1208
Closes #1209
Closes #1210

### Summary

Added full i18n support to the Two-Factor Authentication Setup Flow component using `next-intl`, enabling the 2FA setup experience to be translated across English, Spanish, and Portuguese locales.

### Changes

- **`TwoFactorAuthSetup.tsx`** — Replaced all hardcoded strings with `useTranslations("twoFactorAuth")` hooks for labels, headings, descriptions, error messages, button text, aria-labels, and placeholders
- **`messages/en.json`** — Added `twoFactorAuth` namespace with 19 translation keys covering all UI states (idle, scan, verify, success)
- **`messages/es.json`** — Added Spanish translations for the 2FA setup flow
- **`messages/pt.json`** — Added Portuguese translations for the 2FA setup flow
- **`TwoFactorAuthSetup.test.tsx`** — Mocked `next-intl`'s `useTranslations` to ensure existing tests pass with translated strings

### What's translated

| Key | Description |
|-----|-------------|
| `ariaLabel` / `stepsLabel` | Accessible section and progress indicators |
| `title` / `description` | Idle state heading and explanation |
| `enableButton` / `settingUp` | Enable button and loading state |
| `scanTitle` / `scanDescription` | QR code scan instructions |
| `qrCodeAlt` / `qrCodeSkeletonLabel` | QR image alt text and skeleton label |
| `manualKeyLabel` / `manualKeyAria` | Manual key fallback section |
| `codeInputLabel` / `codeInputPlaceholder` | OTP input field |
| `verifyButton` / `verifying` | Verify button and loading state |
| `successTitle` / `successDescription` | Success confirmation |
| `error.*` | Setup, code length, and invalid code error messages |

### Testing

- All existing unit tests pass with the i18n mock
- Component maintains full accessibility (aria-busy, aria-live, aria-label, role attributes)
- No visual or behavioral regressions — same Tailwind/Drips Wave styling preserved

### Screenshots / GIFs

*(Add before merging)*