### PR TITLE
[Backend] Harden Ledger Monitor: granular metrics, notify refactor, e2e + load tests

### DIFF
--- a/backend/src/lib/horizon-poller.js
+++ b/backend/src/lib/horizon-poller.js
@@ -52,6 +52,8 @@ import {
   ledgerMonitorCycleDuration,
   ledgerMonitorPaymentsChecked,
   ledgerMonitorCircuitBreakerTrips,
+  ledgerMonitorBatchSize,
+  ledgerMonitorRateLimiterWaitSeconds,
   rateLimitRequestsTotal,
   rateLimitExceededTotal,
 } from "./metrics.js";
@@ -205,6 +207,7 @@ export function createLedgerMonitorRateLimiter({
         "Horizon poller: rate limit reached — delaying Horizon request",
       );
       await sleepFn(delayMs);
+      ledgerMonitorRateLimiterWaitSeconds.observe(delayMs / 1000);
       refill();
       tokens = Math.max(0, tokens - 1);
     },
@@ -287,6 +290,8 @@ async function pollPendingPayments() {
       _consecutiveFailures = 0;
       _backoffIndex = 0;
     }
+
+    ledgerMonitorBatchSize.set(pending?.length ?? 0);
 
     if (!pending || pending.length === 0) return;
 
@@ -442,20 +447,22 @@ async function checkPayment(payment, { merchantConfigCache = new Map() } = {}) {
           );
           ledgerMonitorPaymentsChecked.inc({ result: "failed" });
 
-          streamManager.notify(payment.id, "payment.failed", {
-            status: "failed",
-            reason: "underpayment",
-            expected_amount: expected,
-            received_amount: received,
-          });
-          if (_io && payment.merchant_id) {
-            _io.to(`merchant:${payment.merchant_id}`).emit("payment:failed", {
+          notifyPaymentEvent(payment, {
+            sseEvent: "payment.failed",
+            sseData: {
+              status: "failed",
+              reason: "underpayment",
+              expected_amount: expected,
+              received_amount: received,
+            },
+            socketEvent: "payment:failed",
+            socketData: {
               id: payment.id,
               reason: "underpayment",
               expected_amount: expected,
               received_amount: received,
-            });
-          }
+            },
+          });
         } else if (diff > 0.0000001) {
           // Overpayment — confirm but flag
           const latencySeconds = (Date.now() - new Date(payment.created_at).getTime()) / 1000;
@@ -483,18 +490,20 @@ async function checkPayment(payment, { merchantConfigCache = new Map() } = {}) {
             "Horizon poller: overpayment — confirmed with flag",
           );
           ledgerMonitorPaymentsChecked.inc({ result: "confirmed" });
-          streamManager.notify(payment.id, "payment.confirmed", {
-            status: "confirmed",
-            tx_id: anyPayment.transaction_hash,
-            overpayment: true,
-          });
-          if (_io && payment.merchant_id) {
-            _io.to(`merchant:${payment.merchant_id}`).emit("payment:confirmed", {
+          notifyPaymentEvent(payment, {
+            sseEvent: "payment.confirmed",
+            sseData: {
+              status: "confirmed",
+              tx_id: anyPayment.transaction_hash,
+              overpayment: true,
+            },
+            socketEvent: "payment:confirmed",
+            socketData: {
               id: payment.id,
               tx_id: anyPayment.transaction_hash,
               overpayment: true,
-            });
-          }
+            },
+          });
         }
       }
       return;
@@ -585,15 +594,15 @@ async function checkPayment(payment, { merchantConfigCache = new Map() } = {}) {
     );
     ledgerMonitorPaymentsChecked.inc({ result: "confirmed" });
 
-    // SSE → customer checkout page
-    streamManager.notify(payment.id, "payment.confirmed", {
-      status: "confirmed",
-      tx_id: match.transaction_hash,
-    });
-
-    // Socket.io → merchant dashboard
-    if (_io && payment.merchant_id) {
-      _io.to(`merchant:${payment.merchant_id}`).emit("payment:confirmed", {
+    // SSE (customer checkout page) + Socket.io (merchant dashboard)
+    notifyPaymentEvent(payment, {
+      sseEvent: "payment.confirmed",
+      sseData: {
+        status: "confirmed",
+        tx_id: match.transaction_hash,
+      },
+      socketEvent: "payment:confirmed",
+      socketData: {
         id: payment.id,
         amount: payment.amount,
         asset: payment.asset,
@@ -601,8 +610,8 @@ async function checkPayment(payment, { merchantConfigCache = new Map() } = {}) {
         recipient: payment.recipient,
         tx_id: match.transaction_hash,
         confirmed_at: new Date().toISOString(),
-      });
-    }
+      },
+    });
 
     // Webhook
     const merchant = await loadMerchantNotificationConfig(payment.merchant_id, merchantConfigCache);
@@ -660,6 +669,18 @@ async function checkPayment(payment, { merchantConfigCache = new Map() } = {}) {
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Notify both the customer (SSE) and merchant dashboard (Socket.io) of a
+ * payment status change. Consolidates the confirm/fail/overpayment emit
+ * pattern that was previously duplicated at each call site.
+ */
+function notifyPaymentEvent(payment, { sseEvent, sseData, socketEvent, socketData }) {
+  streamManager.notify(payment.id, sseEvent, sseData);
+  if (_io && payment.merchant_id) {
+    _io.to(`merchant:${payment.merchant_id}`).emit(socketEvent, socketData);
+  }
 }
 
 function parsePositiveInt(value, fallback) {

--- a/backend/src/lib/horizon-poller.test.js
+++ b/backend/src/lib/horizon-poller.test.js
@@ -25,6 +25,8 @@ const {
   mockLedgerMonitorCycleDuration,
   mockLedgerMonitorPaymentsChecked,
   mockLedgerMonitorCircuitBreakerTrips,
+  mockLedgerMonitorBatchSize,
+  mockLedgerMonitorRateLimiterWaitSeconds,
   mockRateLimitRequestsTotal,
   mockRateLimitExceededTotal,
   mockLogger,
@@ -46,6 +48,8 @@ const {
   mockLedgerMonitorCycleDuration: { observe: vi.fn() },
   mockLedgerMonitorPaymentsChecked: { inc: vi.fn() },
   mockLedgerMonitorCircuitBreakerTrips: { inc: vi.fn() },
+  mockLedgerMonitorBatchSize: { set: vi.fn() },
+  mockLedgerMonitorRateLimiterWaitSeconds: { observe: vi.fn() },
   mockRateLimitRequestsTotal: { inc: vi.fn() },
   mockRateLimitExceededTotal: { inc: vi.fn() },
   mockLogger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
@@ -95,6 +99,8 @@ vi.mock("./metrics.js", () => ({
   ledgerMonitorCycleDuration: mockLedgerMonitorCycleDuration,
   ledgerMonitorPaymentsChecked: mockLedgerMonitorPaymentsChecked,
   ledgerMonitorCircuitBreakerTrips: mockLedgerMonitorCircuitBreakerTrips,
+  ledgerMonitorBatchSize: mockLedgerMonitorBatchSize,
+  ledgerMonitorRateLimiterWaitSeconds: mockLedgerMonitorRateLimiterWaitSeconds,
   rateLimitRequestsTotal: mockRateLimitRequestsTotal,
   rateLimitExceededTotal: mockRateLimitExceededTotal,
 }));
@@ -112,6 +118,7 @@ import {
   resetPollerState,
   pollOnce,
   createLedgerMonitorRateLimiter,
+  setLedgerMonitorRateLimiterForTest,
 } from "./horizon-poller.js";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -879,7 +886,17 @@ describe("Ledger Monitor — error recovery (Issue #627)", () => {
       // Promise.allSettled accounting loop must handle it (this is the path the
       // old `results` ReferenceError silently broke).
       mockFindMatchingPayment.mockRejectedValue(new Error("horizon down"));
-      mockLedgerMonitorPaymentsChecked.inc.mockImplementation(() => {
+      // The horizon-error branch calls inc({result:"skipped"}) once; when that
+      // throws, checkPayment's own outer catch runs and calls inc() a second
+      // time (also throwing) — that second throw escapes checkPayment entirely,
+      // rejecting the group promise. Two `mockImplementationOnce` calls (one per
+      // inc() invocation in this path) instead of a persistent `mockImplementation`,
+      // which would otherwise leak into every later test in this file —
+      // vi.clearAllMocks() in afterEach clears call history but not implementations.
+      mockLedgerMonitorPaymentsChecked.inc.mockImplementationOnce(() => {
+        throw new Error("metrics backend unavailable");
+      });
+      mockLedgerMonitorPaymentsChecked.inc.mockImplementationOnce(() => {
         throw new Error("metrics backend unavailable");
       });
 
@@ -966,6 +983,211 @@ describe("Ledger Monitor — error recovery (Issue #627)", () => {
       );
       // ...and no per-payment merchant fallback lookups.
       expect(merchantEqMock).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Granular metrics (Issue #1128) ──────────────────────────────────────────
+
+  describe("granular metrics", () => {
+    it("records the fetched batch size as a gauge each cycle", async () => {
+      const payments = [
+        makePayment({ id: "pay-1", recipient: VALID_RECIPIENT_A }),
+        makePayment({ id: "pay-2", recipient: VALID_RECIPIENT_B }),
+      ];
+
+      mockSupabaseFrom.mockImplementation((table) => {
+        if (table === "merchants") {
+          return { select: vi.fn().mockReturnThis(), in: vi.fn().mockResolvedValue({ data: [], error: null }) };
+        }
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          neq: vi.fn().mockReturnThis(),
+          is: vi.fn().mockReturnThis(),
+          gte: vi.fn().mockReturnThis(),
+          order: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockResolvedValue({ data: payments, error: null }),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+          update: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnThis(),
+            is: vi.fn().mockReturnThis(),
+            select: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: { id: "updated" }, error: null }),
+          }),
+        };
+      });
+      mockFindMatchingPayment.mockResolvedValue(null);
+      mockFindAnyRecentPayment.mockResolvedValue(null);
+
+      await pollOnce();
+
+      expect(mockLedgerMonitorBatchSize.set).toHaveBeenCalledWith(2);
+    });
+
+    it("records rate-limiter wait time when Horizon calls are throttled", async () => {
+      const limiter = createLedgerMonitorRateLimiter({ maxPerSecond: 1, burst: 1 });
+      await limiter.waitForSlot(); // consumes the only token
+      await limiter.waitForSlot(); // must throttle and wait
+
+      expect(mockLedgerMonitorRateLimiterWaitSeconds.observe).toHaveBeenCalledWith(
+        expect.any(Number),
+      );
+    });
+  });
+
+  // ── End-to-end mixed-batch poll cycle (Issue #1126) ─────────────────────────
+
+  describe("end-to-end: mixed-outcome batch in a single poll cycle", () => {
+    it("confirms one payment and fails another in the same cycle, isolated per group", async () => {
+      const confirmedPayment = makePayment({
+        id: "pay-confirmed",
+        recipient: VALID_RECIPIENT_A,
+        merchant_id: "merchant-001",
+        amount: "10.0000000",
+      });
+      const underpaidPayment = makePayment({
+        id: "pay-underpaid",
+        recipient: VALID_RECIPIENT_B,
+        merchant_id: "merchant-002",
+        amount: "10.0000000",
+      });
+      const payments = [confirmedPayment, underpaidPayment];
+
+      mockSupabaseFrom.mockImplementation((table) => {
+        if (table === "merchants") {
+          return {
+            select: vi.fn().mockReturnThis(),
+            in: vi.fn().mockResolvedValue({
+              data: [
+                { id: "merchant-001", ...makeMerchant() },
+                { id: "merchant-002", ...makeMerchant() },
+              ],
+              error: null,
+            }),
+          };
+        }
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          neq: vi.fn().mockReturnThis(),
+          is: vi.fn().mockReturnThis(),
+          gte: vi.fn().mockReturnThis(),
+          order: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockResolvedValue({ data: payments, error: null }),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+          update: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnThis(),
+            is: vi.fn().mockReturnThis(),
+            select: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: { id: "updated" }, error: null }),
+          }),
+        };
+      });
+
+      mockFindMatchingPayment.mockImplementation(({ recipient }) =>
+        recipient === VALID_RECIPIENT_A
+          ? Promise.resolve({
+              id: "op-1",
+              transaction_hash: VALID_TX_HASH,
+              received_amount: "10.0000000",
+            })
+          : Promise.resolve(null),
+      );
+      mockFindAnyRecentPayment.mockImplementation(({ recipient }) =>
+        recipient === VALID_RECIPIENT_B
+          ? Promise.resolve({ transaction_hash: "tx-under", received_amount: "5.0000000" })
+          : Promise.resolve(null),
+      );
+
+      await pollOnce();
+
+      // Confirmed group: SSE + merchant socket + counters all fire correctly.
+      expect(mockStreamManagerNotify).toHaveBeenCalledWith(
+        confirmedPayment.id,
+        "payment.confirmed",
+        expect.objectContaining({ status: "confirmed", tx_id: VALID_TX_HASH }),
+      );
+      // Failed group: isolated from the confirmed group, notified independently.
+      expect(mockStreamManagerNotify).toHaveBeenCalledWith(
+        underpaidPayment.id,
+        "payment.failed",
+        expect.objectContaining({ reason: "underpayment" }),
+      );
+      expect(mockLedgerMonitorPaymentsChecked.inc).toHaveBeenCalledWith({ result: "confirmed" });
+      expect(mockLedgerMonitorPaymentsChecked.inc).toHaveBeenCalledWith({ result: "failed" });
+      expect(mockLedgerMonitorBatchSize.set).toHaveBeenCalledWith(2);
+      expect(mockLedgerMonitorCycleDuration.observe).toHaveBeenCalled();
+    });
+  });
+
+  // ── Load test (Issue #1129) ─────────────────────────────────────────────────
+
+  describe("load: high-volume poll cycle", () => {
+    it("processes a large batch of independent payments within one cycle without cross-group interference", async () => {
+      const BATCH = 50; // matches production BATCH_SIZE
+      const payments = Array.from({ length: BATCH }, (_, i) =>
+        makePayment({
+          id: `pay-${i}`,
+          recipient: i % 2 === 0 ? VALID_RECIPIENT_A : VALID_RECIPIENT_B,
+          merchant_id: `merchant-${i % 2}`,
+        }),
+      );
+
+      mockSupabaseFrom.mockImplementation((table) => {
+        if (table === "merchants") {
+          return {
+            select: vi.fn().mockReturnThis(),
+            in: vi.fn().mockResolvedValue({
+              data: [
+                { id: "merchant-0", ...makeMerchant() },
+                { id: "merchant-1", ...makeMerchant() },
+              ],
+              error: null,
+            }),
+          };
+        }
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          neq: vi.fn().mockReturnThis(),
+          is: vi.fn().mockReturnThis(),
+          gte: vi.fn().mockReturnThis(),
+          order: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockResolvedValue({ data: payments, error: null }),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+          update: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnThis(),
+            is: vi.fn().mockReturnThis(),
+            select: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: { id: "updated" }, error: null }),
+          }),
+        };
+      });
+
+      mockFindMatchingPayment.mockResolvedValue({
+        id: "op-load",
+        transaction_hash: VALID_TX_HASH,
+        received_amount: "10.0000000",
+      });
+
+      // Load-test throughput of the group-processing pipeline itself, not the
+      // intentional Horizon rate limit (that's covered separately above).
+      setLedgerMonitorRateLimiterForTest(
+        createLedgerMonitorRateLimiter({ maxPerSecond: 10_000, burst: 10_000 }),
+      );
+
+      const startedAt = Date.now();
+      await pollOnce();
+      const elapsedMs = Date.now() - startedAt;
+
+      // All 50 payments across the two recipient groups were checked and every
+      // notification fired — nothing was dropped under load.
+      expect(mockStreamManagerNotify).toHaveBeenCalledTimes(BATCH);
+      expect(mockLedgerMonitorBatchSize.set).toHaveBeenCalledWith(BATCH);
+      // Sanity ceiling — a full mocked cycle (no real network/DB latency) should
+      // stay well under a second; a large regression here would signal an
+      // accidental serial bottleneck (e.g. losing the per-group concurrency).
+      expect(elapsedMs).toBeLessThan(5_000);
     });
   });
 });

--- a/backend/src/lib/metrics.js
+++ b/backend/src/lib/metrics.js
@@ -130,6 +130,17 @@ export const ledgerMonitorCircuitBreakerTrips = new client.Counter({
   help: "Total number of times the circuit breaker was tripped",
 });
 
+export const ledgerMonitorBatchSize = new client.Gauge({
+  name: "ledger_monitor_batch_size",
+  help: "Number of pending payments fetched in the most recent ledger monitor cycle",
+});
+
+export const ledgerMonitorRateLimiterWaitSeconds = new client.Histogram({
+  name: "ledger_monitor_rate_limiter_wait_seconds",
+  help: "Time spent waiting for a Horizon rate-limit token during a ledger monitor cycle",
+  buckets: [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5],
+});
+
 /**
  * Rate Limiting Metrics
  */
@@ -209,6 +220,8 @@ register.registerMetric(signatureVerificationReplayAttempts);
 register.registerMetric(ledgerMonitorCycleDuration);
 register.registerMetric(ledgerMonitorPaymentsChecked);
 register.registerMetric(ledgerMonitorCircuitBreakerTrips);
+register.registerMetric(ledgerMonitorBatchSize);
+register.registerMetric(ledgerMonitorRateLimiterWaitSeconds);
 register.registerMetric(rateLimitExceededTotal);
 register.registerMetric(rateLimitRequestsTotal);
 register.registerMetric(queryCacheHitTotal);


### PR DESCRIPTION
## Summary

Addresses all four Ledger State Synchronizer (Horizon poller / "Ledger Monitor") tasks in one pass, since they target the same module:
Closes #1126 — end-to-end test covering a single poll cycle with mixed outcomes (confirmed + underpayment-failed) across independent recipient groups, and a load test driving a full 50-payment batch through one cycle.
Closes #1127 — refactor: extracted the duplicated SSE + Socket.io notify pattern (confirm/fail/overpayment call sites) into one `notifyPaymentEvent()` helper.
Closes #1128 — granular metrics: added `ledger_monitor_batch_size` (gauge, cycle fetch size) and `ledger_monitor_rate_limiter_wait_seconds` (histogram, Horizon throttling wait time).
Closes #1129 — load test: full `BATCH_SIZE` (50) payment cycle exercised end-to-end, asserting no cross-group interference or dropped notifications.

Also fixed a latent test-isolation bug found while adding the new tests: the "cycle result aggregation" test primed `ledgerMonitorPaymentsChecked.inc` to throw via a persistent `mockImplementation` instead of `mockImplementationOnce`. `vi.clearAllMocks()` in `afterEach` clears call history but not implementations, so that throwing mock silently leaked into every later test in the file. Fixed to use two scoped `mockImplementationOnce` calls matching the two `inc()` invocations on that code path.

## Test plan

- [x] `vitest run src/lib/horizon-poller.test.js` — 28/28 passing
- [x] Full backend suite run before/after diff — same 32 pre-existing failures (unrelated DB/env-dependent tests: `api-key-rotation`, etc.) in both cases; no new failures introduced